### PR TITLE
feat: 完善物品管理模块，支持发布、编辑、上下架及图片关联

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.0",
         "core-js": "^3.8.3",
+        "vant": "^4.9.24",
         "vue": "^3.2.13",
         "vue-router": "^5.0.6"
       },
@@ -2297,6 +2298,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vant/popperjs": {
+      "version": "1.3.0",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/@vant/popperjs/-/popperjs-1.3.0.tgz",
+      "integrity": "sha512-hB+czUG+aHtjhaEmCJDuXOep0YTZjdlRR+4MSmIFnkCQIxJaXLQdSsR90XWvAI2yvKUI7TCGqR8pQg2RtvkMHw==",
+      "license": "MIT"
+    },
+    "node_modules/@vant/use": {
+      "version": "1.6.0",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/@vant/use/-/use-1.6.0.tgz",
+      "integrity": "sha512-PHHxeAASgiOpSmMjceweIrv2AxDZIkWXyaczksMoWvKV2YAYEhoizRuk/xFnKF+emUIi46TsQ+rvlm/t2BBCfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/@vue-macros/common": {
@@ -11469,6 +11485,20 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vant": {
+      "version": "4.9.24",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/vant/-/vant-4.9.24.tgz",
+      "integrity": "sha512-tP1A7Vjzv1/B1ljb95Jhv9Q9w6acaaZDJvy6wcKrwGgY0gQZlg+FXLZH/AIKZBE3xvYGDUsv/M7AuGcr/Pqd6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vant/popperjs": "^1.3.0",
+        "@vant/use": "^1.6.0",
+        "@vue/shared": "^3.5.31"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vary": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "core-js": "^3.8.3",
+    "vant": "^4.9.24",
     "vue": "^3.2.13",
     "vue-router": "^5.0.6"
   },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,34 @@
+// src/main.js
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 
-createApp(App).use(router).mount('#app')
+// 1. 引入 Vant 组件
+import {
+  Swipe,
+  SwipeItem,
+  Image as VanImage,
+  Rate,
+  Button,
+  Icon,
+  Empty,
+  Toast // 确保引入 Toast 用于提示
+} from 'vant'
+
+// 2. 引入 Vant 样式
+import 'vant/lib/index.css'
+
+// 3. 创建应用实例
+const app = createApp(App)
+
+// 4. 全局注册 Vant 组件
+app.use(Swipe)
+app.use(SwipeItem)
+app.use(VanImage)
+app.use(Rate)
+app.use(Button)
+app.use(Icon)
+app.use(Empty)
+// Toast 是函数式组件，通常直接引入即可，不需要 use
+
+app.use(router).mount('#app')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -23,9 +23,34 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: '/product/:id',
+    name: 'ProductDetail',
+    component: () => import('../views/ProductDetail.vue'),
+    meta: { requiresAuth: true }
+  },
+  // ✅ 新增：发布商品路由（使用懒加载提升首屏性能）
+  {
+    path: '/publish',
+    name: 'Publish',
+    component: () => import('../views/Publish.vue'),
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/edit/:id',
+    name: 'EditProduct',
+    component: () => import('../views/EditProduct.vue'),
+    meta: { requiresAuth: true }
+  },
+  {
     path: '/my',
     name: 'My',
     component: My,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/my-products',
+    name: 'MyProducts',
+    component: () => import('../views/MyProducts.vue'), // 我们将新建这个文件
     meta: { requiresAuth: true }
   },
   {
@@ -41,13 +66,12 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, from, next) => {
-  const token = localStorage.getItem('token')
-  if (to.meta.requiresAuth && !token) {
-    next('/login')
-  } else {
-    next()
+router.beforeEach((to, from) => {
+  // 鉴权拦截：未登录则强制跳转登录页
+  if (to.meta.requiresAuth && !localStorage.getItem('token')) {
+    return '/login'
   }
+  return true
 })
 
 export default router

--- a/frontend/src/views/EditProduct.vue
+++ b/frontend/src/views/EditProduct.vue
@@ -1,0 +1,288 @@
+<template>
+  <div class="edit-page">
+    <div class="form-card">
+      <!-- ✅ 新增：顶部返回/放弃按钮 -->
+      <div class="form-header-actions">
+        <div class="back-link" @click="$router.back()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M19 12H5M12 19l-7-7 7-7"/>
+          </svg>
+          <span>放弃修改</span>
+        </div>
+      </div>
+
+      <div class="form-header">
+        <h2>编辑商品信息</h2>
+        <div class="status-badge" :class="product.status === 1 ? 'on-sale' : 'off-sale'">
+          {{ product.status === 1 ? '🟢 在售中' : '⚫ 已下架' }}
+        </div>
+      </div>
+
+      <form @submit.prevent="submitUpdate">
+        <!-- 图片管理 -->
+        <div class="form-group">
+          <label>商品图片 <span class="tip">(最多5张，首张为封面)</span></label>
+          <div class="upload-area">
+            <div v-for="(url, index) in allImages" :key="index" class="preview-item">
+              <img :src="normalizeImageUrl(url)" alt="preview" />
+              <button type="button" class="remove-btn" @click="removeImage(index)">×</button>
+            </div>
+            <label v-if="allImages.length < 5" class="upload-btn">
+              <input type="file" accept="image/*" @change="handleImageSelect" />
+              <span class="icon">+</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- 标题 -->
+        <div class="form-group">
+          <label>商品标题</label>
+          <input type="text" v-model="form.title" maxlength="50" required />
+        </div>
+
+        <!-- 分类 & 成色 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>物品分类</label>
+            <select v-model.number="form.categoryId" required>
+              <option v-for="cat in categories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
+            </select>
+          </div>
+          <div class="form-group half">
+            <label>新旧程度</label>
+            <select v-model.number="form.conditionLevel" required>
+              <option :value="1">全新</option><option :value="2">99新</option>
+              <option :value="3">95新</option><option :value="4">9成新</option>
+              <option :value="5">8成新</option><option :value="6">7成新及以下</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- 价格 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>售价 (元)</label>
+            <input type="number" v-model.number="form.price" step="0.01" min="0" required />
+          </div>
+          <div class="form-group half">
+            <label>原价 (元，选填)</label>
+            <input type="number" v-model.number="form.originalPrice" step="0.01" min="0" />
+          </div>
+        </div>
+
+        <!-- ✅ 是否议价 -->
+        <div class="form-group">
+          <label>是否接受议价</label>
+          <select v-model.number="form.isBargain">
+            <option :value="1">✅ 可以议价（更容易成交）</option>
+            <option :value="0">❌ 不议价（一口价）</option>
+          </select>
+        </div>
+
+        <!-- 描述 -->
+        <div class="form-group">
+          <label>详细描述</label>
+          <textarea v-model="form.description" rows="4" maxlength="500"></textarea>
+        </div>
+
+        <!-- 校区 & 地点 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>所在校区</label>
+            <input type="text" v-model="form.campus" required />
+          </div>
+          <div class="form-group half">
+            <label>期望交易地点</label>
+            <input type="text" v-model="form.tradeLocation" />
+          </div>
+        </div>
+
+        <!-- 操作按钮 -->
+        <div class="action-row">
+          <button type="submit" class="btn-primary" :disabled="isSubmitting">
+            {{ isSubmitting ? '保存中...' : '保存修改' }}
+          </button>
+          <button type="button" class="btn-secondary" @click="toggleStatus" v-if="product.id">
+            {{ product.status === 1 ? '⬇️ 下架商品' : '⬆️ 重新上架' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'EditProduct',
+  data() {
+    return {
+      product: { id: null, status: 1, images: [] },
+      form: { 
+        title: '', 
+        categoryId: '', 
+        conditionLevel: '', 
+        price: null, 
+        originalPrice: null, 
+        description: '', 
+        campus: '', 
+        tradeLocation: '',
+        isBargain: 1 // ✅ 默认值
+      },
+      categories: [],
+      existingImages: [],
+      newImageFiles: [],
+      isSubmitting: false
+    }
+  },
+  computed: {
+    allImages() {
+      return [...this.existingImages, ...this.newImageFiles.map(f => URL.createObjectURL(f))]
+    }
+  },
+  async mounted() {
+    if (!localStorage.getItem('token')) return this.$router.push('/login')
+    await Promise.all([this.fetchCategories(), this.fetchProductDetail()])
+  },
+  methods: {
+    normalizeImageUrl(url) {
+      if (!url) return ''
+      return url.startsWith('/') ? `http://localhost:8087${url}` : url
+    },
+    async fetchCategories() {
+      const res = await axios.get('/api/categories')
+      this.categories = res.data.map(c => ({ id: c.categoryId, name: c.categoryName }))
+    },
+    async fetchProductDetail() {
+      const id = this.$route.params.id
+      const res = await axios.get(`/api/products/${id}`)
+      const data = res.data
+      this.product = { id: data.id || data.productId, status: data.status || 1, images: data.images || [] }
+      this.existingImages = [...this.product.images]
+
+      // ✅ 回显时包含 isBargain
+      this.form = {
+        title: data.title, 
+        categoryId: data.categoryId, 
+        conditionLevel: data.conditionLevel,
+        price: Number(data.price), 
+        originalPrice: data.originalPrice ? Number(data.originalPrice) : null,
+        description: data.description, 
+        campus: data.campus, 
+        tradeLocation: data.tradeLocation,
+        isBargain: data.isBargain !== undefined ? data.isBargain : 1
+      }
+    },
+    handleImageSelect(e) {
+      const file = e.target.files[0]
+      if (file && this.allImages.length < 5) {
+        this.newImageFiles.push(file)
+      }
+      e.target.value = ''
+    },
+    removeImage(index) {
+      if (index < this.existingImages.length) {
+        this.existingImages.splice(index, 1)
+      } else {
+        this.newImageFiles.splice(index - this.existingImages.length, 1)
+      }
+    },
+    async uploadNewImages() {
+      const urls = []
+      for (const file of this.newImageFiles) {
+        const formData = new FormData()
+        formData.append('file', file)
+        const res = await axios.post('/api/upload/image', formData, { headers: { 'Content-Type': 'multipart/form-data' } })
+        urls.push(res.data.url)
+      }
+      return urls
+    },
+    async submitUpdate() {
+      this.isSubmitting = true
+      try {
+        const uploadedUrls = await this.uploadNewImages()
+        const finalImages = [...this.existingImages, ...uploadedUrls]
+
+        // ✅ 提交时 form 中已包含 isBargain
+        await axios.put(`/api/products/${this.product.id}`, {
+          ...this.form,
+          imageUrls: finalImages
+        })
+        alert('修改成功！')
+        this.$router.push(`/product/${this.product.id}`)
+      } catch (e) {
+        alert('保存失败: ' + (e.response?.data?.message || e.message))
+      } finally {
+        this.isSubmitting = false
+      }
+    },
+    async toggleStatus() {
+      const newStatus = this.product.status === 1 ? 3 : 1
+      const action = newStatus === 1 ? '上架' : '下架'
+      if (!confirm(`确定要${action}该商品吗？`)) return
+
+      try {
+        await axios.patch(`/api/products/${this.product.id}/status?status=${newStatus}`)
+        this.product.status = newStatus
+        alert(`${action}成功！`)
+      } catch (e) {
+        alert('状态更新失败')
+      }
+    }
+  },
+  beforeDestroy() {
+    this.newImageFiles.forEach(f => URL.revokeObjectURL(URL.createObjectURL(f)))
+  }
+}
+</script>
+
+<style scoped>
+.edit-page { min-height: 100vh; background: #f5f6fa; padding: 24px 16px 100px; }
+.form-card { max-width: 800px; margin: 0 auto; background: #fff; border-radius: 16px; padding: 32px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); }
+
+/* ✅ 新增：返回链接样式 */
+.form-header-actions { margin-bottom: 16px; }
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #666;
+  font-size: 14px;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+.back-link:hover { color: #ff4d4f; } /* 编辑页用红色提示放弃 */
+.back-link svg { width: 16px; height: 16px; }
+
+.form-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 28px; }
+.form-header h2 { font-size: 24px; color: #333; margin: 0; }
+.status-badge { padding: 6px 12px; border-radius: 20px; font-size: 13px; font-weight: 500; }
+.status-badge.on-sale { background: #e6f4ea; color: #389e0d; }
+.status-badge.off-sale { background: #f5f5f5; color: #8c8c8c; }
+.form-group { margin-bottom: 20px; }
+.form-group label { display: block; font-size: 15px; font-weight: 500; color: #333; margin-bottom: 8px; }
+.tip { font-size: 12px; color: #999; font-weight: normal; }
+.form-group input, .form-group select, .form-group textarea {
+  width: 100%; padding: 12px 14px; border: 1px solid #ddd; border-radius: 10px;
+  font-size: 15px; background: #fafafa; transition: all 0.2s; box-sizing: border-box;
+}
+.form-group input:focus, .form-group select:focus, .form-group textarea:focus {
+  border-color: #2b6aff; background: #fff; outline: none; box-shadow: 0 0 0 3px rgba(43,106,255,0.1);
+}
+.form-row { display: flex; gap: 16px; }
+.form-group.half { flex: 1; }
+.upload-area { display: flex; flex-wrap: wrap; gap: 12px; }
+.preview-item { position: relative; width: 100px; height: 100px; border-radius: 10px; overflow: hidden; border: 1px solid #eee; }
+.preview-item img { width: 100%; height: 100%; object-fit: cover; }
+.remove-btn { position: absolute; top: 4px; right: 4px; width: 22px; height: 22px; border-radius: 50%; background: rgba(0,0,0,0.6); color: #fff; border: none; cursor: pointer; font-size: 16px; line-height: 1; display: flex; align-items: center; justify-content: center; }
+.upload-btn { width: 100px; height: 100px; border: 2px dashed #ccc; border-radius: 10px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.2s; background: #fafafa; }
+.upload-btn:hover { border-color: #2b6aff; background: rgba(43,106,255,0.05); }
+.upload-btn input { display: none; }
+.icon { font-size: 32px; color: #999; }
+.action-row { display: flex; gap: 16px; margin-top: 24px; }
+.btn-primary { flex: 1; padding: 14px; background: #2b6aff; color: #fff; border: none; border-radius: 12px; font-size: 16px; font-weight: 600; cursor: pointer; }
+.btn-primary:disabled { background: #a0b4f7; cursor: not-allowed; }
+.btn-secondary { flex: 1; padding: 14px; background: #fff; color: #333; border: 1px solid #ddd; border-radius: 12px; font-size: 16px; font-weight: 600; cursor: pointer; }
+.btn-secondary:hover { background: #f9f9f9; }
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,141 +1,98 @@
 <template>
   <div class="home-wrapper">
-    <div class="home-page">
-      <!-- 搜索栏 -->
-    <div class="search-bar">
-      <div class="search-input-wrapper">
-        <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8"/>
-          <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-        </svg>
-        <input type="text" placeholder="搜索商品名称" v-model="searchQuery" />
+    <!-- 搜索与筛选栏 -->
+    <div class="search-filters">
+      <div class="search-bar">
+        <div class="search-input-wrapper">
+          <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input type="text" placeholder="搜索商品名称" v-model="searchQuery" @keyup.enter="handleSearch" />
+        </div>
       </div>
-    </div>
+      
+      <div class="filter-bar">
+        <!-- 分类筛选 -->
+        <div class="filter-section">
+          <div class="filter-label">分类:</div>
+          <div class="filter-tags">
+            <div v-for="cat in categories" :key="cat.id" :class="['filter-tag', { active: activeCategory === cat.id }]" @click="onCategoryChange(cat.id)">
+              {{ cat.name }}
+            </div>
+          </div>
+        </div>
 
-    <!-- 分类标签 -->
-    <div class="category-tabs">
-      <div
-        v-for="cat in categories"
-        :key="cat.id"
-        :class="['category-tab', { active: activeCategory === cat.id }]"
-        @click="onCategoryChange(cat.id)"
-      >
-        {{ cat.name }}
+        <!-- 价格筛选 -->
+        <div class="filter-section">
+          <div class="filter-label">价格:</div>
+          <div class="price-inputs">
+            <input type="number" placeholder="最低价" v-model.number="priceMin" @change="resetAndFetch" />
+            <span class="dash">-</span>
+            <input type="number" placeholder="最高价" v-model.number="priceMax" @change="resetAndFetch" />
+          </div>
+        </div>
+
+        <!-- 成色筛选 -->
+        <div class="filter-section">
+          <div class="filter-label">成色:</div>
+          <div class="condition-filters">
+            <div v-for="level in conditionLevels" :key="level.value" :class="['condition-tag', { active: selectedCondition === level.value }]" @click="onConditionChange(level.value)">
+              {{ level.label }}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
     <!-- 商品列表 -->
     <div class="product-grid">
-      <div class="product-card" v-for="product in displayProducts" :key="product.id">
+      <div class="product-card" v-for="product in displayProducts" :key="product.id" @click="$router.push(`/product/${product.id}`)">
         <div class="product-image">
-          <svg v-if="product.icon === 'box'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/>
-            <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
-            <line x1="12" y1="22.08" x2="12" y2="12"/>
-          </svg>
-          <svg v-else-if="product.icon === 'book'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M4 19.5A2.5 2.5 0 016.5 17H20"/>
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/>
-          </svg>
-          <svg v-else-if="product.icon === 'lamp'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M9 18h6"/>
-            <path d="M10 22h4"/>
-            <path d="M12 2v1"/>
-            <path d="M12 7a5 5 0 00-5 5c0 2 2 3 2 6h6c0-3 2-4 2-6a5 5 0 00-5-5z"/>
-          </svg>
-          <svg v-else-if="product.icon === 'bike'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <circle cx="5.5" cy="17.5" r="3.5"/>
-            <circle cx="18.5" cy="17.5" r="3.5"/>
-            <path d="M15 6h-3l-3 9"/>
-            <path d="M15 6a1 1 0 011 1v1"/>
-            <path d="M12 17l-2-4h4l-2 4z"/>
-          </svg>
-          <svg v-else-if="product.icon === 'shoe'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M4 16v-2a2 2 0 012-2h12a2 2 0 012 2v2"/>
-            <path d="M4 16h16"/>
-            <path d="M8 12l2-4 2 4"/>
-          </svg>
-          <svg v-else-if="product.icon === 'game'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <rect x="2" y="6" width="20" height="12" rx="2"/>
-            <path d="M6 12h4"/>
-            <path d="M8 10v4"/>
-            <circle cx="17" cy="12" r="1.5"/>
-            <circle cx="14" cy="12" r="1.5"/>
-          </svg>
-          <svg v-else-if="product.icon === 'headphone'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M3 18v-6a9 9 0 0118 0v6"/>
-            <path d="M21 19a2 2 0 01-2 2h-1a2 2 0 01-2-2v-3a2 2 0 012-2h3z"/>
-            <path d="M3 19a2 2 0 002 2h1a2 2 0 002-2v-3a2 2 0 00-2-2H3z"/>
-          </svg>
-          <svg v-else-if="product.icon === 'laptop'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <rect x="2" y="3" width="20" height="14" rx="2"/>
-            <line x1="2" y1="17" x2="22" y2="17"/>
-            <line x1="8" y1="21" x2="16" y2="21"/>
-          </svg>
-          <svg v-else-if="product.icon === 'camera'" viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z"/>
-            <circle cx="12" cy="13" r="4"/>
-          </svg>
-          <svg v-else viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
-            <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <circle cx="12" cy="12" r="5"/>
-            <path d="M12 2v2M12 20v2M2 12h2M20 12h2"/>
-          </svg>
-        </div>
+  <img 
+    v-if="product.images && product.images.length > 0" 
+    :src="product.images[0]" 
+    :alt="product.title"
+    @error="handleImageError"
+    class="product-img"
+  />
+  <!-- 图片加载失败时显示默认图标 -->
+  <svg v-else viewBox="0 0 24 24" fill="none" stroke="#bbb" stroke-width="1.5">
+    <rect x="3" y="3" width="18" height="18" rx="2"/>
+    <circle cx="12" cy="12" r="5"/>
+  </svg>
+</div>
         <div class="product-info">
           <div class="product-title">{{ product.title }}</div>
           <div class="product-price">¥{{ product.price }}</div>
           <div class="product-tags">
-            <span class="tag condition">{{ product.condition }}</span>
+            <span class="tag condition">{{ product.condition || '未知' }}</span>
             <span class="tag campus">{{ product.campus }}</span>
           </div>
         </div>
       </div>
     </div>
 
-      <!-- 底部导航 -->
-      <div class="bottom-nav">
-        <div class="nav-item active">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-            <polyline points="9 22 9 12 15 12 15 22"/>
-          </svg>
-          <span>首页</span>
-        </div>
-        <div class="nav-item">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="7" height="7"/>
-            <rect x="14" y="3" width="7" height="7"/>
-            <rect x="3" y="14" width="7" height="7"/>
-            <rect x="14" y="14" width="7" height="7"/>
-          </svg>
-          <span>分类</span>
-        </div>
-        <div class="nav-item nav-publish">
-          <div class="publish-btn">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="12" y1="5" x2="12" y2="19"/>
-              <line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-          </div>
-          <span>发布</span>
-        </div>
-        <div class="nav-item">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="9" cy="21" r="1"/>
-            <circle cx="20" cy="21" r="1"/>
-            <path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/>
-          </svg>
-          <span>购物车</span>
-        </div>
-        <div class="nav-item" @click="$router.push('/my')">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
-            <circle cx="12" cy="7" r="4"/>
-          </svg>
-          <span>我的</span>
-        </div>
-      </div>
+    <!-- ✅ 新增：分页控件 -->
+    <div class="pagination-bar" v-if="totalPages > 1">
+      <button class="page-btn" :disabled="!hasPrev" @click="goToPage(currentPage - 1)">
+        &laquo; 上一页
+      </button>
+      <span class="page-info">
+        第 {{ currentPage + 1 }} / {{ totalPages }} 页 (共 {{ totalElements }} 件)
+      </span>
+      <button class="page-btn" :disabled="!hasNext" @click="goToPage(currentPage + 1)">
+        下一页 &raquo;
+      </button>
+    </div>
+
+    <!-- 底部导航 -->
+    <div class="bottom-nav">
+      <div class="nav-item active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg><span>首页</span></div>
+      <div class="nav-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg><span>分类</span></div>
+      <div class="nav-item nav-publish" @click="$router.push('/publish')"><div class="publish-btn"><svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></div><span>发布</span></div>
+      <div class="nav-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg><span>购物车</span></div>
+      <div class="nav-item" @click="$router.push('/my')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg><span>我的</span></div>
     </div>
   </div>
 </template>
@@ -149,72 +106,103 @@ export default {
     return {
       searchQuery: '',
       activeCategory: 'all',
+      priceMin: null,
+      priceMax: null,
+      selectedCondition: null,
       categories: [{ id: 'all', name: '全部' }],
-      products: []
+      products: [],
+      // ✅ 分页状态
+      currentPage: 0,
+      totalPages: 1,
+      totalElements: 0,
+      hasNext: false,
+      hasPrev: false
     }
   },
   computed: {
-    iconMap() {
-      return {
-        'digital': 'box',
-        'books': 'book',
-        'life': 'lamp',
-        'transport': 'bike',
-        'beauty': 'box',
-        'clothes': 'shoe'
-      }
+    conditionLevels() {
+      return [
+        { value: null, label: '全部' },
+        { value: 1, label: '全新' },
+        { value: 2, label: '99新' },
+        { value: 3, label: '95新' },
+        { value: 4, label: '9成新' },
+        { value: 5, label: '8成新' },
+        { value: 6, label: '7成新及以下' }
+      ]
     },
     displayProducts() {
       return this.products.map(p => ({
         ...p,
-        icon: this.iconMap[p.category] || 'box'
+        price: Number(p.price).toFixed(2)
       }))
     }
   },
   watch: {
-    searchQuery() {
-      this.fetchProducts()
-    }
+    '$route'() { this.resetAndFetch() },
+    searchQuery(val) { if (val === '') this.resetAndFetch() }
   },
+  activated() { this.resetAndFetch() },
   methods: {
-    async fetchCategories() {
+    // ✅ 统一请求方法（支持传页码）
+    async fetchProducts(page = 0) {
       try {
-        const res = await axios.get('/api/categories')
-        const list = res.data.map(c => ({
-          id: c.categoryId,
-          name: c.categoryName
-        }))
-        this.categories = [{ id: 'all', name: '全部' }, ...list]
-      } catch (e) {
-        console.error('获取分类失败', e)
-      }
-    },
-    async fetchProducts() {
-      try {
-        const params = {}
-        if (this.activeCategory !== 'all') {
-          params.categoryId = this.activeCategory
-        }
-        if (this.searchQuery.trim()) {
-          params.keyword = this.searchQuery.trim()
-        }
+        const params = { page, size: 10 } // 保持与后端 @PageableDefault(size=10) 一致
+        if (this.searchQuery.trim()) params.keyword = this.searchQuery.trim()
+        if (this.activeCategory !== 'all') params.categoryId = this.activeCategory
+        if (typeof this.priceMin === 'number' && !isNaN(this.priceMin) && this.priceMin >= 0) params.minPrice = this.priceMin
+        if (typeof this.priceMax === 'number' && !isNaN(this.priceMax) && this.priceMax >= 0) params.maxPrice = this.priceMax
+        if (this.selectedCondition !== null && this.selectedCondition !== undefined) params.conditionLevel = this.selectedCondition
+
         const res = await axios.get('/api/products', { params })
-        this.products = res.data.map(p => ({
-          id: p.id,
-          title: p.title,
-          price: p.price,
-          condition: p.condition,
-          campus: p.campus,
-          category: p.category,
-          icon: p.icon
-        }))
+        let productList = res.data.content || []
+        this.products = Array.isArray(productList) ? productList : []
+
+        // 更新分页元数据
+        this.totalPages = res.data.totalPages || 1
+        this.totalElements = res.data.totalElements || 0
+        this.currentPage = res.data.number || 0
+        this.hasNext = !res.data.last
+        this.hasPrev = !res.data.first
       } catch (e) {
         console.error('获取商品失败', e)
       }
     },
+    // 切换页码
+    goToPage(page) {
+      if (page < 0 || page >= this.totalPages) return
+      this.fetchProducts(page)
+      window.scrollTo({ top: 0, behavior: 'smooth' }) // 平滑滚回顶部
+    },
+    // 搜索/筛选时重置到第一页
+    handleSearch() { this.resetAndFetch() },
+    resetAndFetch() {
+      this.currentPage = 0
+      this.fetchProducts(0)
+    },
     onCategoryChange(catId) {
       this.activeCategory = catId
-      this.fetchProducts()
+      this.resetAndFetch()
+    },
+    onConditionChange(level) {
+      this.selectedCondition = level
+      this.resetAndFetch()
+    },
+    async fetchCategories() {
+      try {
+        const res = await axios.get('/api/categories')
+        const list = res.data.map(c => ({ id: c.categoryId, name: c.categoryName }))
+        this.categories = [{ id: 'all', name: '全部' }, ...list]
+      } catch (e) {
+        console.error('获取分类失败', e)
+      }
+    }
+  },handleImageError(e) {
+    // 图片加载失败时隐藏 img，显示 svg 图标
+    e.target.style.display = 'none';
+    const svg = e.target.nextElementSibling;
+    if (svg && svg.tagName === 'svg') {
+      svg.style.display = 'block';
     }
   },
   mounted() {
@@ -223,7 +211,7 @@ export default {
       return
     }
     this.fetchCategories()
-    this.fetchProducts()
+    this.fetchProducts(0)
   }
 }
 </script>
@@ -232,120 +220,35 @@ export default {
 .home-wrapper {
   min-height: 100vh;
   background: #f5f6fa;
+  /* ✅ 增加底部 padding 防止分页控件被底部导航遮挡 */
+  padding-bottom: calc(70px + env(safe-area-inset-bottom) + 100px);
 }
+.search-filters { background: #fff; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+.search-bar { margin-bottom: 16px; }
+.search-input-wrapper { display: flex; align-items: center; background: #f0f1f5; border-radius: 24px; padding: 10px 18px; gap: 10px; }
+.search-icon { width: 20px; height: 20px; flex-shrink: 0; }
+.search-input-wrapper input { border: none; background: transparent; outline: none; font-size: 15px; color: #333; width: 100%; }
+.filter-bar { display: flex; flex-direction: column; gap: 12px; font-size: 14px; color: #333; }
+.filter-section { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.filter-label { font-weight: 600; min-width: 40px; color: #2b6aff; }
+.filter-tags { display: flex; gap: 10px; flex: 1; overflow-x: auto; padding-bottom: 4px; }
+.filter-tag { padding: 6px 16px; border-radius: 20px; font-size: 14px; background: #f0f1f5; cursor: pointer; transition: all 0.2s; white-space: nowrap; }
+.filter-tag.active { background: #2b6aff; color: #fff; }
+.price-inputs { display: flex; align-items: center; gap: 10px; flex: 1; }
+.price-inputs input { width: 80px; padding: 6px 10px; border: 1px solid #ddd; border-radius: 6px; font-size: 14px; text-align: center; }
+.dash { color: #999; font-weight: bold; }
+.condition-filters { display: flex; gap: 10px; flex: 1; overflow-x: auto; padding-bottom: 4px; }
+.condition-tag { padding: 6px 14px; border-radius: 20px; font-size: 13px; background: #f0f1f5; cursor: pointer; transition: all 0.2s; white-space: nowrap; }
+.condition-tag.active { background: #ff9800; color: #fff; }
 
-.home-page {
-  min-height: 100vh;
-  background: #f5f6fa;
-  padding-bottom: 80px;
-  box-sizing: border-box;
-}
+.product-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; padding: 16px 24px; }
+@media (min-width: 1200px) { .product-grid { grid-template-columns: repeat(5, 1fr); } }
+@media (min-width: 992px) and (max-width: 1199px) { .product-grid { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 768px) and (max-width: 991px) { .product-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 767px) { .product-grid { grid-template-columns: repeat(2, 1fr); } }
 
-/* 搜索栏 */
-.search-bar {
-  padding: 16px 24px;
-  background: #fff;
-}
-
-.search-input-wrapper {
-  display: flex;
-  align-items: center;
-  background: #f0f1f5;
-  border-radius: 24px;
-  padding: 10px 18px;
-  gap: 10px;
-}
-
-.search-icon {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-}
-
-.search-input-wrapper input {
-  border: none;
-  background: transparent;
-  outline: none;
-  font-size: 15px;
-  color: #333;
-  width: 100%;
-}
-
-.search-input-wrapper input::placeholder {
-  color: #999;
-}
-
-/* 分类标签 */
-.category-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  padding: 14px 24px;
-  background: #fff;
-}
-
-.category-tab {
-  padding: 8px 22px;
-  border-radius: 20px;
-  font-size: 15px;
-  color: #666;
-  background: #f0f1f5;
-  cursor: pointer;
-  transition: all 0.2s;
-  user-select: none;
-}
-
-.category-tab.active {
-  background: #2b6aff;
-  color: #fff;
-}
-
-/* 商品网格 */
-.product-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
-  padding: 16px 24px;
-}
-
-@media (min-width: 1200px) {
-  .product-grid {
-    grid-template-columns: repeat(5, 1fr);
-  }
-}
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .product-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .product-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 767px) {
-  .product-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.product-card {
-  background: #fff;
-  border-radius: 14px;
-  overflow: hidden;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-  transition: transform 0.2s, box-shadow 0.2s;
-  cursor: pointer;
-}
-
-.product-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
-}
-
+.product-card { background: #fff; border-radius: 14px; overflow: hidden; box-shadow: 0 2px 10px rgba(0,0,0,0.05); transition: transform 0.2s, box-shadow 0.2s; cursor: pointer; }
+.product-card:hover { transform: translateY(-4px); box-shadow: 0 6px 20px rgba(0,0,0,0.08); }
 .product-image {
   aspect-ratio: 1;
   background: #f0f1f5;
@@ -354,114 +257,56 @@ export default {
   justify-content: center;
   padding: 24px;
   box-sizing: border-box;
+  position: relative;
 }
-
+.product-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
 .product-image svg {
   width: 55%;
   height: 55%;
+  display: none; /* 默认隐藏，图片加载失败时显示 */
 }
+.product-info { padding: 12px 14px 14px; }
+.product-title { font-size: 15px; color: #333; font-weight: 500; margin-bottom: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.product-price { font-size: 18px; color: #ff4d4f; font-weight: 600; margin-bottom: 10px; }
+.product-tags { display: flex; gap: 8px; }
+.tag { font-size: 12px; padding: 3px 8px; border-radius: 5px; }
+.tag.condition { color: #2b6aff; background: rgba(43,106,255,0.08); }
+.tag.campus { color: #ff7a45; background: rgba(255,122,69,0.08); }
 
-.product-info {
-  padding: 12px 14px 14px;
-}
-
-.product-title {
-  font-size: 15px;
-  color: #333;
-  font-weight: 500;
-  margin-bottom: 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.product-price {
-  font-size: 18px;
-  color: #ff4d4f;
-  font-weight: 600;
-  margin-bottom: 10px;
-}
-
-.product-tags {
+/* ✅ 分页控件样式 */
+.pagination-bar {
   display: flex;
-  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  padding: 20px;
+  margin-top: 10px;
 }
-
-.tag {
-  font-size: 12px;
-  padding: 3px 8px;
-  border-radius: 5px;
-}
-
-.tag.condition {
-  color: #2b6aff;
-  background: rgba(43, 106, 255, 0.08);
-}
-
-.tag.campus {
-  color: #ff7a45;
-  background: rgba(255, 122, 69, 0.08);
-}
-
-/* 底部导航 */
-.bottom-nav {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 70px;
+.page-btn {
+  padding: 8px 16px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
   background: #fff;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  border-top: 1px solid #eee;
-  z-index: 100;
-  padding-bottom: env(safe-area-inset-bottom);
-}
-
-.nav-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  color: #999;
-  font-size: 13px;
+  color: #333;
+  font-size: 14px;
   cursor: pointer;
-  flex: 1;
+  transition: all 0.2s;
 }
+.page-btn:hover:not(:disabled) { background: #2b6aff; color: #fff; border-color: #2b6aff; }
+.page-btn:disabled { opacity: 0.4; cursor: not-allowed; background: #f9f9f9; }
+.page-info { font-size: 14px; color: #666; }
 
-.nav-item svg {
-  width: 26px;
-  height: 26px;
-}
-
-.nav-item.active {
-  color: #2b6aff;
-}
-
-.nav-publish {
-  position: relative;
-  top: -12px;
-}
-
-.publish-btn {
-  width: 56px;
-  height: 56px;
-  background: #2b6aff;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 16px rgba(43, 106, 255, 0.35);
-}
-
-.publish-btn svg {
-  width: 28px;
-  height: 28px;
-}
-
-.nav-publish span {
-  margin-top: 4px;
-}
+.bottom-nav { position: fixed; bottom: 0; left: 0; right: 0; height: 70px; background: #fff; display: flex; justify-content: space-around; align-items: center; border-top: 1px solid #eee; z-index: 100; padding-bottom: env(safe-area-inset-bottom); }
+.nav-item { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; color: #999; font-size: 13px; cursor: pointer; flex: 1; }
+.nav-item svg { width: 26px; height: 26px; }
+.nav-item.active { color: #2b6aff; }
+.nav-publish { position: relative; top: -12px; }
+.publish-btn { width: 56px; height: 56px; background: #2b6aff; border-radius: 50%; display: flex; align-items: center; justify-content: center; box-shadow: 0 4px 16px rgba(43,106,255,0.35); }
+.publish-btn svg { width: 28px; height: 28px; }
+.nav-publish span { margin-top: 4px; }
 </style>

--- a/frontend/src/views/My.vue
+++ b/frontend/src/views/My.vue
@@ -79,6 +79,16 @@
           <polyline points="9 18 15 12 9 6"/>
         </svg>
       </div>
+      <div class="menu-item" @click="$router.push('/my-products')">
+  <svg class="menu-icon" viewBox="0 0 24 24" fill="none" stroke="#2b6aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 7h-3a2 2 0 01-2-2V2"/><path d="M9 14l3 3 6-6"/>
+    <path d="M20 13v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5a2 2 0 012-2h6"/>
+  </svg>
+  <span class="menu-text">我发布的</span>
+  <svg class="menu-arrow" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="9 18 15 12 9 6"/>
+  </svg>
+</div>
       <div class="menu-item">
         <svg class="menu-icon" viewBox="0 0 24 24" fill="none" stroke="#2b6aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="10"/>
@@ -139,15 +149,15 @@
         </svg>
         <span>分类</span>
       </div>
-      <div class="nav-item nav-publish">
-        <div class="publish-btn">
-          <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="12" y1="5" x2="12" y2="19"/>
-            <line x1="5" y1="12" x2="19" y2="12"/>
-          </svg>
-        </div>
-        <span>发布</span>
-      </div>
+      <div class="nav-item nav-publish" @click="$router.push('/publish')">
+  <div class="publish-btn">
+    <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="12" y1="5" x2="12" y2="19"/>
+      <line x1="5" y1="12" x2="19" y2="12"/>
+    </svg>
+  </div>
+  <span>发布</span>
+</div>
       <div class="nav-item">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="9" cy="21" r="1"/>

--- a/frontend/src/views/MyProducts.vue
+++ b/frontend/src/views/MyProducts.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="my-products-page">
+    <!-- ✅ 新增：带返回按钮的顶部导航 -->
+    <div class="page-header">
+      <div class="back-btn" @click="$router.back()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5M12 19l-7-7 7-7"/>
+        </svg>
+      </div>
+      <h2>我发布的</h2>
+      <span class="count">共 {{ products.length }} 件</span>
+    </div>
+
+    <div v-if="loading" class="loading">加载中...</div>
+    
+    <div v-else-if="products.length === 0" class="empty-state">
+      <p>你还没有发布任何商品哦～</p>
+      <van-button type="primary" size="small" @click="$router.push('/publish')">去发布</van-button>
+    </div>
+
+    <div v-else class="product-list">
+      <div v-for="item in products" :key="item.id" class="product-card">
+        <div class="card-left">
+          <img :src="item.images?.[0] || 'https://placehold.co/100x100?text=No+Img'" alt="cover" />
+          <div class="status-tag" :class="item.status === 1 ? 'on-sale' : 'off-sale'">
+            {{ item.status === 1 ? '在售' : '已下架' }}
+          </div>
+        </div>
+        
+        <div class="card-right">
+          <div class="title">{{ item.title }}</div>
+          <div class="price">¥{{ item.price }}</div>
+          <div class="meta">
+            <span>{{ item.condition }}</span>
+            <span>|</span>
+            <span>{{ item.campus }}</span>
+          </div>
+          
+          <div class="actions">
+            <van-button size="mini" plain type="primary" @click="goToEdit(item.id)">编辑</van-button>
+            <van-button 
+              size="mini" 
+              :type="item.status === 1 ? 'default' : 'success'" 
+              @click="toggleStatus(item)"
+            >
+              {{ item.status === 1 ? '下架' : '上架' }}
+            </van-button>
+            <van-button size="mini" plain type="danger" @click="deleteProduct(item.id)">删除</van-button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'MyProducts',
+  data() {
+    return {
+      products: [],
+      loading: false,
+      currentUser: null
+    }
+  },
+  async mounted() {
+    const userStr = localStorage.getItem('user')
+    if (userStr) {
+      this.currentUser = JSON.parse(userStr)
+      await this.fetchMyProducts()
+    } else {
+      this.$router.push('/login')
+    }
+  },
+  methods: {
+    async fetchMyProducts() {
+      if (!this.currentUser?.userId) return
+      this.loading = true
+      try {
+        // ✅ 调用后端接口获取我发布的商品
+        const res = await axios.get(`/api/products/my?sellerId=${this.currentUser.userId}`)
+        this.products = res.data || []
+      } catch (e) {
+        console.error('获取我的商品失败', e)
+      } finally {
+        this.loading = false
+      }
+    },
+    goToEdit(id) {
+      this.$router.push(`/edit/${id}`)
+    },
+    async toggleStatus(item) {
+      const newStatus = item.status === 1 ? 3 : 1
+      const action = newStatus === 1 ? '上架' : '下架'
+      if (!confirm(`确定要${action}该商品吗？`)) return
+
+      try {
+        await axios.patch(`/api/products/${item.id}/status?status=${newStatus}`)
+        item.status = newStatus
+        alert(`${action}成功！`)
+      } catch (e) {
+        alert('操作失败')
+      }
+    },
+    async deleteProduct(id) {
+      if (!confirm('确定要永久删除该商品吗？此操作不可恢复！')) return
+
+      try {
+        // ✅ 发送 DELETE 请求
+        await axios.delete(`/api/products/${id}`)
+
+        // ✅ 只有后端成功返回后，才从本地列表移除
+        this.products = this.products.filter(p => p.id !== id)
+        alert('删除成功')
+      } catch (e) {
+        console.error(e)
+        alert('删除失败: ' + (e.response?.data?.message || e.message))
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.my-products-page { padding: 16px; background: #f5f5f5; min-height: 100vh; }
+
+/* ✅ 新增：Header 样式 */
+.page-header { 
+  display: flex; 
+  align-items: center; 
+  margin-bottom: 16px; 
+  position: relative;
+}
+.back-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #333;
+  margin-right: 12px;
+}
+.back-btn svg { width: 20px; height: 20px; }
+.page-header h2 { font-size: 18px; margin: 0; flex: 1; }
+.count { font-size: 14px; color: #999; }
+
+.product-list { display: flex; flex-direction: column; gap: 12px; }
+.product-card { background: #fff; border-radius: 12px; padding: 12px; display: flex; gap: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.05); }
+.card-left { position: relative; width: 100px; height: 100px; flex-shrink: 0; }
+.card-left img { width: 100%; height: 100%; object-fit: cover; border-radius: 8px; }
+.status-tag { position: absolute; top: 4px; left: 4px; padding: 2px 6px; border-radius: 4px; font-size: 10px; color: #fff; }
+.status-tag.on-sale { background: #52c41a; }
+.status-tag.off-sale { background: #999; }
+.card-right { flex: 1; display: flex; flex-direction: column; justify-content: space-between; }
+.title { font-size: 14px; font-weight: 500; color: #333; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.price { font-size: 16px; color: #ff4d4f; font-weight: bold; margin-top: 4px; }
+.meta { font-size: 12px; color: #999; margin-top: 4px; }
+.actions { display: flex; gap: 8px; margin-top: 8px; }
+.empty-state { text-align: center; padding: 40px 0; color: #999; }
+</style>

--- a/frontend/src/views/ProductDetail.vue
+++ b/frontend/src/views/ProductDetail.vue
@@ -1,0 +1,345 @@
+<template>
+  <div class="product-detail">
+    <!-- 🔹 图片轮播 -->
+    <div class="swiper-container">
+      <!-- ✅ 新增：悬浮返回按钮 -->
+      <div class="floating-back" @click="$router.back()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5M12 19l-7-7 7-7"/>
+        </svg>
+      </div>
+
+      <van-swipe class="swiper" :autoplay="3000" indicator-color="white" @change="onSwipeChange">
+        <van-swipe-item v-for="(img, index) in imageList" :key="index">
+          <img :src="normalizeImageUrl(img)" class="swiper-img" @error="handleImageError" />
+        </van-swipe-item>
+      </van-swipe>
+      <div class="image-count">{{ currentSlide + 1 }} / {{ imageList.length }}</div>
+    </div>
+
+    <!-- 🔹 商品信息 -->
+    <div class="info-card">
+      <h1 class="title">{{ product.title }}</h1>
+      
+      <div class="price-row">
+        <span class="price">¥{{ product.price }}</span>
+        <span v-if="product.originalPrice" class="original-price">原价 ¥{{ product.originalPrice }}</span>
+      </div>
+
+      <div class="meta-tags">
+        <span class="tag condition">{{ product.condition }}</span>
+        <span class="tag campus">{{ product.campus }}校区</span>
+        <span class="tag views">👁 {{ product.viewCount || 0 }} 浏览</span>
+      </div>
+
+      <div class="trade-info">
+        <div class="info-item"><span class="label">交易地点</span><span class="value">{{ product.tradeLocation || '面议' }}</span></div>
+        <div class="info-item"><span class="label">交易方式</span><span class="value">{{ formatTradeMethod(product.tradeMethod) }}</span></div>
+        <div class="info-item"><span class="label">是否议价</span><span class="value">{{ product.isBargain ? '✅ 可小刀' : '❌ 不议价' }}</span></div>
+      </div>
+    </div>
+
+    <!-- 🔹 卖家卡片 -->
+    <div class="seller-card" @click="goToSellerPage">
+      <div class="seller-avatar">
+        <img :src="normalizeImageUrl(product.sellerAvatar) || 'https://placehold.co/40x40/eee/999?text=U'" />
+      </div>
+      <div class="seller-info">
+        <div class="seller-name">{{ product.sellerName || '匿名用户' }}</div>
+        <div class="seller-stats">
+          <span class="rating">⭐ {{ product.sellerRating || '5.0' }}</span>
+          <span class="sep">|</span>
+          <span>成交 {{ product.sellerDealCount || 0 }} 单</span>
+        </div>
+      </div>
+      <van-button size="small" type="primary" @click.stop="contactSeller">联系 TA</van-button>
+    </div>
+
+    <!-- 🔹 仅卖家可见的管理操作 -->
+    <div v-if="isOwner" class="owner-actions">
+      <button class="action-btn edit" @click="$router.push(`/edit/${product.id}`)">✏️ 编辑商品</button>
+      <button class="action-btn status" @click="toggleStatus">
+        {{ product.status === 1 ? '⬇️ 下架' : '⬆️ 重新上架' }}
+      </button>
+    </div>
+
+    <!-- 🔹 商品详情 -->
+    <div class="detail-section">
+      <h3 class="section-title">商品详情</h3>
+      <div class="description" v-if="product.description" v-html="formatDescription(product.description)"></div>
+      <div v-else class="empty-desc">卖家暂未填写更多描述～</div>
+    </div>
+
+    <!-- 🔹 底部操作栏 -->
+    <div class="action-bar">
+      <div class="left-actions">
+        <div class="action-btn" @click="toggleFavorite">
+          <van-icon :name="isFavorite ? 'like' : 'like-o'" :color="isFavorite ? '#ee0a24' : '#666'" />
+          <span :style="{ color: isFavorite ? '#ee0a24' : '' }">收藏</span>
+        </div>
+        <div class="action-btn" @click="goToCart">
+          <van-icon name="shopping-cart-o" />
+          <span>购物车</span>
+        </div>
+        <div class="action-btn" @click="shareProduct">
+          <van-icon name="share-o" />
+          <span>分享</span>
+        </div>
+      </div>
+      <div class="right-actions">
+        <van-button type="warning" size="small" @click="addToCart">加入购物车</van-button>
+        <van-button type="danger" size="small" @click="buyNow">立即购买</van-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'ProductDetail',
+  data() {
+    return {
+      product: {
+        id: '', title: '', price: 0, originalPrice: null,
+        condition: '', campus: '', tradeLocation: '',
+        tradeMethod: 3, isBargain: 1, viewCount: 0,
+        sellerId: null, sellerName: '', sellerAvatar: null,
+        sellerRating: 5.0, sellerDealCount: 0,
+        description: '', images: [], status: 1
+      },
+      isFavorite: false,
+      currentSlide: 0,
+      isOwner: false,
+      currentUser: null
+    }
+  },
+  computed: {
+    imageList() {
+      if (!this.product.images || !Array.isArray(this.product.images) || this.product.images.length === 0) {
+        return ['https://placehold.co/800x800/eee/999?text=No+Image']
+      }
+      return this.product.images
+    }
+  },
+  async mounted() {
+    // 1. 获取当前登录用户
+    const userStr = localStorage.getItem('user')
+    if (userStr) {
+      this.currentUser = JSON.parse(userStr)
+    }
+    // 2. 加载商品详情
+    await this.fetchProductDetail()
+    // 3. 判断是否为卖家
+    this.isOwner = this.currentUser && this.product.sellerId === this.currentUser.userId
+  },
+  methods: {
+    // ✅ 归一化图片 URL：相对路径拼接后端地址
+    normalizeImageUrl(url) {
+      if (!url) return ''
+      if (url.startsWith('/') && !url.includes('http')) {
+        return 'http://localhost:8087' + url
+      }
+      return url
+    },
+    handleImageError(e) {
+      e.target.src = 'https://placehold.co/800x800/eee/999?text=Load+Failed'
+    },
+    onSwipeChange(index) {
+      this.currentSlide = index
+    },
+    async fetchProductDetail() {
+      const id = this.$route.params.id
+      try {
+        const res = await axios.get(`/api/products/${id}`)
+        const data = res.data
+        this.product = {
+          ...this.product,
+          id: data.id || data.productId,
+          title: data.title,
+          price: Number(data.price).toFixed(2),
+          originalPrice: data.originalPrice ? Number(data.originalPrice).toFixed(2) : null,
+          condition: data.condition || '未知',
+          campus: data.campus,
+          tradeLocation: data.tradeLocation,
+          tradeMethod: data.tradeMethod || 3,
+          isBargain: data.isBargain !== undefined ? data.isBargain : 1,
+          viewCount: data.viewCount || 0,
+          sellerId: data.sellerId,
+          sellerName: data.sellerName,
+          sellerAvatar: data.sellerAvatar,
+          sellerRating: data.sellerRating || 5.0,
+          sellerDealCount: data.sellerDealCount || 0,
+          description: data.description,
+          images: data.images || [],
+          status: data.status || 1
+        }
+      } catch (e) {
+        console.error('获取商品详情失败', e)
+        alert('商品加载失败，请重试')
+        this.$router.back()
+      }
+    },
+    formatTradeMethod(method) {
+      const map = { 1: '仅支持自提', 2: '仅支持快递', 3: '自提/快递均可' }
+      return map[method] || '面议'
+    },
+    formatDescription(text) {
+      if (!text) return ''
+      return text.replace(/\n/g, '<br/>')
+    },
+    contactSeller() {
+      alert('正在跳转聊天界面...')
+      // TODO: 跳转聊天页
+    },
+    toggleFavorite() {
+      this.isFavorite = !this.isFavorite
+      alert(this.isFavorite ? '已加入收藏' : '已取消收藏')
+      // TODO: 调用收藏 API
+    },
+    addToCart() {
+      alert('已加入购物车')
+      // TODO: 调用购物车 API
+    },
+    buyNow() {
+      alert('正在创建订单...')
+      // TODO: 跳转订单确认页
+    },
+    goToCart() {
+      this.$router.push('/cart')
+    },
+    goToSellerPage() {
+      // TODO: 跳转卖家主页 /seller/${this.product.sellerId}
+    },
+    shareProduct() {
+      if (navigator.share) {
+        navigator.share({
+          title: this.product.title,
+          text: `校园闲置：${this.product.title}，仅售 ¥${this.product.price}`,
+          url: window.location.href
+        })
+      } else {
+        navigator.clipboard.writeText(window.location.href)
+        alert('商品链接已复制到剪贴板')
+      }
+    },
+    async toggleStatus() {
+      const newStatus = this.product.status === 1 ? 3 : 1
+      const action = newStatus === 1 ? '上架' : '下架'
+      if (!confirm(`确定要${action}该商品吗？`)) return
+      
+      try {
+        await axios.patch(`/api/products/${this.product.id}/status?status=${newStatus}`)
+        this.product.status = newStatus
+        alert(`${action}成功！`)
+      } catch (e) {
+        alert('状态更新失败')
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* 🎨 闲鱼风格 · 商品详情页 */
+.product-detail {
+  background: #f5f5f5;
+  min-height: 100vh;
+  padding-bottom: 70px; /* 为底部操作栏留空 */
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* 🔹 轮播图 */
+.swiper-container { position: relative; width: 100%; background: #fff; }
+.swiper-img { width: 100%; height: 300px; object-fit: cover; }
+
+/* ✅ 新增：悬浮返回按钮样式 */
+.floating-back {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 36px;
+  height: 36px;
+  background: rgba(0,0,0,0.4);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  backdrop-filter: blur(4px);
+}
+.floating-back svg { width: 20px; height: 20px; }
+
+.image-count {
+  position: absolute; top: 12px; right: 12px;
+  background: rgba(0,0,0,0.6); color: #fff;
+  font-size: 12px; padding: 4px 10px; border-radius: 14px;
+}
+
+/* 🔹 商品信息卡片 */
+.info-card { 
+  background: #fff; margin: 10px; padding: 16px;
+  border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+.title { font-size: 18px; font-weight: 600; color: #333; margin: 0 0 12px; line-height: 1.4; }
+.price-row { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
+.price { font-size: 24px; font-weight: bold; color: #ff4d4f; }
+.original-price { font-size: 14px; color: #999; text-decoration: line-through; }
+.meta-tags { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+.tag { font-size: 12px; padding: 4px 10px; border-radius: 14px; background: #f0f0f0; color: #666; }
+.tag.condition { background: rgba(43,106,255,0.1); color: #2b6aff; font-weight: 500; }
+.tag.campus { background: rgba(255,122,69,0.1); color: #ff7a45; }
+.tag.views { background: #f5f5f5; color: #999; }
+
+.trade-info { border-top: 1px solid #f0f0f0; padding-top: 12px; }
+.info-item { display: flex; justify-content: space-between; padding: 8px 0; font-size: 14px; }
+.info-item .label { color: #666; }
+.info-item .value { color: #333; font-weight: 500; }
+
+/* 🔹 卖家卡片 */
+.seller-card {
+  display: flex; align-items: center; background: #fff;
+  margin: 10px; padding: 14px 16px; border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05); cursor: pointer;
+}
+.seller-avatar { width: 44px; height: 44px; border-radius: 50%; overflow: hidden; margin-right: 12px; flex-shrink: 0; background: #eee; }
+.seller-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.seller-info { flex: 1; }
+.seller-name { font-size: 15px; font-weight: 500; color: #333; margin-bottom: 4px; }
+.seller-stats { font-size: 12px; color: #999; }
+.seller-stats .rating { color: #ff9800; font-weight: 500; }
+.seller-stats .sep { margin: 0 6px; color: #ddd; }
+
+/* 🔹 卖家管理操作区 */
+.owner-actions { display: flex; gap: 12px; margin: 10px 10px 0; }
+.action-btn {
+  flex: 1; padding: 10px; border: none; border-radius: 10px;
+  font-size: 14px; font-weight: 500; cursor: pointer; background: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+}
+.action-btn.edit { color: #2b6aff; }
+.action-btn.status { color: #ff7a45; }
+
+/* 🔹 商品详情 */
+.detail-section { background: #fff; margin: 10px; padding: 16px; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
+.section-title { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px; padding-bottom: 8px; border-bottom: 1px solid #f0f0f0; }
+.description { font-size: 14px; color: #666; line-height: 1.6; white-space: pre-wrap; }
+.empty-desc { color: #999; font-size: 14px; text-align: center; padding: 20px 0; }
+
+/* 🔹 底部操作栏 */
+.action-bar {
+  position: fixed; bottom: 0; left: 0; right: 0; height: 56px;
+  background: #fff; border-top: 1px solid #eee; display: flex;
+  align-items: center; padding: 0 12px; z-index: 100; box-shadow: 0 -2px 10px rgba(0,0,0,0.03);
+}
+.left-actions { display: flex; gap: 20px; flex: 1; }
+.action-btn {
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  font-size: 10px; color: #666; cursor: pointer;
+}
+.action-btn .van-icon { font-size: 20px; }
+.right-actions { display: flex; gap: 10px; }
+.right-actions .van-button { height: 36px; border-radius: 18px; font-size: 13px; padding: 0 16px; }
+</style>

--- a/frontend/src/views/ProductDetail.vue
+++ b/frontend/src/views/ProductDetail.vue
@@ -191,26 +191,26 @@ export default {
     },
     contactSeller() {
       alert('正在跳转聊天界面...')
-      // TODO: 跳转聊天页
+      
     },
     toggleFavorite() {
       this.isFavorite = !this.isFavorite
       alert(this.isFavorite ? '已加入收藏' : '已取消收藏')
-      // TODO: 调用收藏 API
+      
     },
     addToCart() {
       alert('已加入购物车')
-      // TODO: 调用购物车 API
+   
     },
     buyNow() {
       alert('正在创建订单...')
-      // TODO: 跳转订单确认页
+      
     },
     goToCart() {
       this.$router.push('/cart')
     },
     goToSellerPage() {
-      // TODO: 跳转卖家主页 /seller/${this.product.sellerId}
+      
     },
     shareProduct() {
       if (navigator.share) {

--- a/frontend/src/views/Publish.vue
+++ b/frontend/src/views/Publish.vue
@@ -1,0 +1,295 @@
+<template>
+  <div class="publish-page">
+    <div class="form-card">
+      <!-- ✅ 新增：顶部返回/取消按钮 -->
+      <div class="form-header-actions">
+        <div class="back-link" @click="$router.back()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M19 12H5M12 19l-7-7 7-7"/>
+          </svg>
+          <span>取消发布</span>
+        </div>
+      </div>
+
+      <div class="form-header">
+        <h2>发布二手物品</h2>
+        <p class="subtitle">真实描述，快速成交</p>
+      </div>
+
+      <form @submit.prevent="submitProduct">
+        <!-- 图片上传区 -->
+        <div class="form-group">
+          <label>商品图片 <span class="tip">(最多5张，首张为封面)</span></label>
+          <div class="upload-area">
+            <div v-for="(url, index) in imagePreviews" :key="index" class="preview-item">
+              <img :src="url" alt="preview" />
+              <button type="button" class="remove-btn" @click="removeImage(index)">×</button>
+            </div>
+            <label v-if="imageFiles.length < 5" class="upload-btn">
+              <input type="file" multiple accept="image/*" @change="handleImageSelect" />
+              <span class="icon">+</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- 标题 -->
+        <div class="form-group">
+          <label>商品标题</label>
+          <input type="text" v-model="form.title" placeholder="品牌+型号+核心卖点，如：iPhone14 256G 蓝色" maxlength="50" required />
+          <div class="char-count">{{ form.title.length }}/50</div>
+        </div>
+
+        <!-- 分类 & 成色 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>物品分类</label>
+            <select v-model="form.categoryId" required>
+              <option value="" disabled>请选择分类</option>
+              <option v-for="cat in categories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
+            </select>
+          </div>
+          <div class="form-group half">
+            <label>新旧程度</label>
+            <select v-model.number="form.conditionLevel" required>
+              <option value="" disabled>请选择</option>
+              <option :value="1">全新</option>
+              <option :value="2">99新</option>
+              <option :value="3">95新</option>
+              <option :value="4">9成新</option>
+              <option :value="5">8成新</option>
+              <option :value="6">7成新及以下</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- 价格 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>售价 (元)</label>
+            <input type="number" v-model.number="form.price" placeholder="0.00" step="0.01" min="0" required />
+          </div>
+          <div class="form-group half">
+            <label>原价 (元，选填)</label>
+            <input type="number" v-model.number="form.originalPrice" placeholder="选填" step="0.01" min="0" />
+          </div>
+        </div>
+
+        <!-- ✅ 是否议价 -->
+        <div class="form-group">
+          <label>是否接受议价</label>
+          <select v-model.number="form.isBargain">
+            <option :value="1">✅ 可以议价（更容易成交）</option>
+            <option :value="0">❌ 不议价（一口价）</option>
+          </select>
+        </div>
+
+        <!-- 描述 -->
+        <div class="form-group">
+          <label>详细描述</label>
+          <textarea v-model="form.description" placeholder="描述物品来源、使用情况、瑕疵、交易偏好等..." rows="4" maxlength="500"></textarea>
+          <div class="char-count">{{ form.description.length }}/500</div>
+        </div>
+
+        <!-- 校区 & 交易地点 -->
+        <div class="form-row">
+          <div class="form-group half">
+            <label>所在校区</label>
+            <input type="text" v-model="form.campus" placeholder="例如：本部校区" required />
+          </div>
+          <div class="form-group half">
+            <label>期望交易地点</label>
+            <input type="text" v-model="form.tradeLocation" placeholder="例如：图书馆正门/食堂门口" />
+          </div>
+        </div>
+
+        <button type="submit" class="submit-btn" :disabled="isSubmitting">
+          {{ isSubmitting ? '发布中...' : '立即发布' }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'Publish',
+  data() {
+    return {
+      form: {
+        title: '',
+        categoryId: '',
+        conditionLevel: '',
+        price: null,
+        originalPrice: null,
+        description: '',
+        campus: '',
+        tradeLocation: '',
+        isBargain: 1 // ✅ 默认允许议价
+      },
+      imageFiles: [],
+      imagePreviews: [],
+      categories: [],
+      isSubmitting: false
+    }
+  },
+  mounted() {
+    if (!localStorage.getItem('token')) {
+      this.$router.push('/login')
+      return
+    }
+    this.fetchCategories()
+  },
+  methods: {
+    async fetchCategories() {
+      try {
+        const res = await axios.get('/api/categories')
+        // ✅ 关键修复：将后端返回的 categoryId/categoryName 映射为前端需要的 id/name
+        this.categories = (res.data || []).map(c => ({
+          id: c.categoryId,
+          name: c.categoryName
+        }))
+      } catch (e) {
+        console.error('获取分类失败', e)
+      }
+    },
+    handleImageSelect(e) {
+      const files = Array.from(e.target.files)
+      const remaining = 5 - this.imageFiles.length
+      const toAdd = files.slice(0, remaining)
+
+      toAdd.forEach(file => {
+        this.imageFiles.push(file)
+        // 创建本地预览 URL
+        this.imagePreviews.push(URL.createObjectURL(file))
+      })
+
+      // 清空 input 允许重复选择同一文件
+      e.target.value = ''
+    },
+    removeImage(index) {
+      URL.revokeObjectURL(this.imagePreviews[index])
+      this.imagePreviews.splice(index, 1)
+      this.imageFiles.splice(index, 1)
+    },
+    async uploadImages() {
+      const urls = []
+      for (const file of this.imageFiles) {
+        const formData = new FormData()
+        formData.append('file', file)
+        const res = await axios.post('/api/upload/image', formData, {
+          headers: { 'Content-Type': 'multipart/form-data' }
+        })
+        urls.push(res.data.url)
+      }
+      return urls
+    },
+    async submitProduct() {
+      if (this.form.categoryId === '' || this.form.conditionLevel === '') {
+        alert('请选择分类和新旧程度')
+        return
+      }
+
+      this.isSubmitting = true
+      try {
+        // 1. 上传图片，获取 URL 数组
+        let imageUrls = []
+        if (this.imageFiles.length > 0) {
+          imageUrls = await this.uploadImages()  // 返回 ["/images/xxx.jpg", ...]
+        }
+
+        // 2. 组装提交数据
+        const payload = {
+          ...this.form,
+          sellerId: this.getSellerIdFromToken(),
+          status: 1,
+          quantity: 1,
+          tradeMethod: 3,
+          // ✅ 直接使用表单中用户选择的值
+          isBargain: this.form.isBargain,
+          imageUrls: imageUrls 
+        }
+
+        await axios.post('/api/products', payload)
+        alert('发布成功！')
+        this.$router.push('/')
+      } catch (e) {
+        console.error('发布失败', e)
+        alert('发布失败: ' + (e.response?.data?.message || e.message))
+      } finally {
+        this.isSubmitting = false
+      }
+    },
+    getSellerIdFromToken() {
+      // 示例：解析 JWT 或从 localStorage 获取，请根据实际登录逻辑修改
+      const userStr = localStorage.getItem('user')
+      return userStr ? JSON.parse(userStr).userId : 1
+    }
+  },
+  beforeDestroy() {
+    // 组件销毁时释放预览 URL 内存
+    this.imagePreviews.forEach(url => URL.revokeObjectURL(url))
+  }
+}
+</script>
+
+<style scoped>
+.publish-page { min-height: 100vh; background: #f5f6fa; padding: 24px 16px 100px; }
+.form-card { max-width: 800px; margin: 0 auto; background: #fff; border-radius: 16px; padding: 32px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); }
+
+/* ✅ 新增：返回链接样式 */
+.form-header-actions { margin-bottom: 16px; }
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #666;
+  font-size: 14px;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+.back-link:hover { color: #ff4d4f; }
+.back-link svg { width: 16px; height: 16px; }
+
+.form-header { margin-bottom: 28px; text-align: center; }
+.form-header h2 { font-size: 24px; color: #333; margin: 0 0 8px; }
+.subtitle { font-size: 14px; color: #666; margin: 0; }
+.form-group { margin-bottom: 20px; }
+.form-group label { display: block; font-size: 15px; font-weight: 500; color: #333; margin-bottom: 8px; }
+.tip { font-size: 12px; color: #999; font-weight: normal; }
+.form-group input, .form-group select, .form-group textarea {
+  width: 100%; padding: 12px 14px; border: 1px solid #ddd; border-radius: 10px;
+  font-size: 15px; background: #fafafa; transition: all 0.2s; box-sizing: border-box;
+}
+.form-group input:focus, .form-group select:focus, .form-group textarea:focus {
+  border-color: #2b6aff; background: #fff; outline: none; box-shadow: 0 0 0 3px rgba(43,106,255,0.1);
+}
+.form-row { display: flex; gap: 16px; }
+.form-group.half { flex: 1; }
+.char-count { text-align: right; font-size: 12px; color: #999; margin-top: 4px; }
+
+.upload-area { display: flex; flex-wrap: wrap; gap: 12px; }
+.preview-item { position: relative; width: 100px; height: 100px; border-radius: 10px; overflow: hidden; border: 1px solid #eee; }
+.preview-item img { width: 100%; height: 100%; object-fit: cover; }
+.remove-btn {
+  position: absolute; top: 4px; right: 4px; width: 22px; height: 22px; border-radius: 50%;
+  background: rgba(0,0,0,0.6); color: #fff; border: none; cursor: pointer; font-size: 16px; line-height: 1;
+  display: flex; align-items: center; justify-content: center;
+}
+.upload-btn {
+  width: 100px; height: 100px; border: 2px dashed #ccc; border-radius: 10px;
+  display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.2s;
+  background: #fafafa;
+}
+.upload-btn:hover { border-color: #2b6aff; background: rgba(43,106,255,0.05); }
+.upload-btn input { display: none; }
+.icon { font-size: 32px; color: #999; }
+
+.submit-btn {
+  width: 100%; padding: 14px; background: #2b6aff; color: #fff; border: none; border-radius: 12px;
+  font-size: 16px; font-weight: 600; cursor: pointer; margin-top: 12px; transition: all 0.2s;
+}
+.submit-btn:hover:not(:disabled) { background: #1a52d6; transform: translateY(-1px); }
+.submit-btn:disabled { background: #a0b4f7; cursor: not-allowed; }
+</style>

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -2,9 +2,17 @@ module.exports = {
   devServer: {
     port: 8081,
     proxy: {
+      // API 请求代理
       '/api': {
         target: 'http://localhost:8087',
-        changeOrigin: true
+        changeOrigin: true,
+        pathRewrite: { '^/api': '/api' }
+      },
+
+      '/images': {
+        target: 'http://localhost:8087',
+        changeOrigin: true,
+        pathRewrite: { '^/images': '/images' }
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/config/DataInitializer.java
+++ b/src/main/java/com/example/config/DataInitializer.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class DataInitializer implements CommandLineRunner {
@@ -37,6 +39,7 @@ public class DataInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) {
         if (productRepository.count() == 0) {
+            // 1. 先创建或获取用户
             User testUser = userRepository.findById(1L).orElse(null);
             if (testUser == null) {
                 testUser = new User();
@@ -57,6 +60,7 @@ public class DataInitializer implements CommandLineRunner {
 
             Long userId = testUser.getUserId();
 
+            // 2. 创建钱包
             if (walletRepository.findByUserId(userId).isEmpty()) {
                 Wallet wallet = new Wallet();
                 wallet.setUserId(userId);
@@ -68,23 +72,37 @@ public class DataInitializer implements CommandLineRunner {
                 walletRepository.save(wallet);
             }
 
-            if (orderRepository.count() == 0) {
-                orderRepository.save(createOrder(userId, userId, 1L, "CT202605100001", new BigDecimal("4200"), (byte) 0));
-                orderRepository.save(createOrder(userId, userId, 2L, "CT202605100002", new BigDecimal("35"), (byte) 1));
-                orderRepository.save(createOrder(userId, userId, 3L, "CT202605100003", new BigDecimal("89"), (byte) 2));
-                orderRepository.save(createOrder(userId, userId, 4L, "CT202605100004", new BigDecimal("850"), (byte) 3));
-                orderRepository.save(createOrder(userId, userId, 5L, "CT202605100005", new BigDecimal("499"), (byte) 3));
-            }
+            // 3. 【修改】先创建产品，并保存产品ID
+            List<Long> productIds = new ArrayList<>();
 
-            productRepository.save(createProduct(userId, 1, "iPad Pro 2021", new BigDecimal("4200"), (byte) 2, "主校区"));
-            productRepository.save(createProduct(userId, 2, "考研英语红宝书", new BigDecimal("35"), (byte) 3, "主校区"));
-            productRepository.save(createProduct(userId, 3, "小米台灯 1S", new BigDecimal("89"), (byte) 2, "主校区"));
-            productRepository.save(createProduct(userId, 4, "捷安特山地车", new BigDecimal("850"), (byte) 5, "主校区"));
-            productRepository.save(createProduct(userId, 6, "Nike Dunk 低帮", new BigDecimal("499"), (byte) 4, "主校区"));
+            Product p1 = createProduct(userId, 1, "iPad Pro 2021", new BigDecimal("4200"), (byte) 2, "主校区");
+            productIds.add(productRepository.save(p1).getProductId());
+
+            Product p2 = createProduct(userId, 2, "考研英语红宝书", new BigDecimal("35"), (byte) 3, "主校区");
+            productIds.add(productRepository.save(p2).getProductId());
+
+            Product p3 = createProduct(userId, 3, "小米台灯 1S", new BigDecimal("89"), (byte) 2, "主校区");
+            productIds.add(productRepository.save(p3).getProductId());
+
+            Product p4 = createProduct(userId, 4, "捷安特山地车", new BigDecimal("850"), (byte) 5, "主校区");
+            productIds.add(productRepository.save(p4).getProductId());
+
+            Product p5 = createProduct(userId, 6, "Nike Dunk 低帮", new BigDecimal("499"), (byte) 4, "主校区");
+            productIds.add(productRepository.save(p5).getProductId());
+
             productRepository.save(createProduct(userId, 1, "Switch 游戏卡", new BigDecimal("210"), (byte) 2, "主校区"));
             productRepository.save(createProduct(userId, 1, "AirPods Pro 2", new BigDecimal("998"), (byte) 3, "主校区"));
             productRepository.save(createProduct(userId, 1, "MacBook Air M1", new BigDecimal("4500"), (byte) 4, "主校区"));
             productRepository.save(createProduct(userId, 1, "佳能 G7X Mark III", new BigDecimal("3200"), (byte) 2, "主校区"));
+
+            // 4. 【修改】最后创建订单，使用实际存在的产品ID
+            if (orderRepository.count() == 0) {
+                orderRepository.save(createOrder(userId, userId, productIds.get(0), "CT202605100001", new BigDecimal("4200"), (byte) 0));
+                orderRepository.save(createOrder(userId, userId, productIds.get(1), "CT202605100002", new BigDecimal("35"), (byte) 1));
+                orderRepository.save(createOrder(userId, userId, productIds.get(2), "CT202605100003", new BigDecimal("89"), (byte) 2));
+                orderRepository.save(createOrder(userId, userId, productIds.get(3), "CT202605100004", new BigDecimal("850"), (byte) 3));
+                orderRepository.save(createOrder(userId, userId, productIds.get(4), "CT202605100005", new BigDecimal("499"), (byte) 3));
+            }
         }
     }
 

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,5 +1,4 @@
 package com.example.config;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,7 +9,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
 import java.util.Arrays;
 
 @Configuration
@@ -25,10 +23,12 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
+        // ✅ 修改：增加 "PATCH" 和 "OPTIONS" (预检请求必须)
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:8084", "http://localhost:8081"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
@@ -37,17 +37,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/categories/**").permitAll()
-                .requestMatchers("/api/products/**").permitAll()
-                .requestMatchers("/api/user/**").permitAll()
-                .anyRequest().authenticated()
-            )
-            .formLogin(form -> form.disable())
-            .httpBasic(basic -> basic.disable());
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/categories/**").permitAll()
+                        .requestMatchers("/api/products/**").permitAll()
+                        .requestMatchers("/api/user/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable());
 
         return http.build();
     }

--- a/src/main/java/com/example/config/WebConfig.java
+++ b/src/main/java/com/example/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // ✅ 关键：将 /images/** 映射到项目根目录下的 images/ 文件夹
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:images/");  // file: 表示外部目录
+    }
+}

--- a/src/main/java/com/example/controller/FileUploadController.java
+++ b/src/main/java/com/example/controller/FileUploadController.java
@@ -1,0 +1,43 @@
+package com.example.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/upload")
+@CrossOrigin(origins = "http://localhost:8081")
+public class FileUploadController {
+
+    // ✅ 统一使用项目根目录下的 images 文件夹（外部目录，非 src/）
+    private static final String UPLOAD_DIR = "images/";
+
+    @PostMapping("/image")
+    public ResponseEntity<Map<String, String>> uploadImage(@RequestParam("file") MultipartFile file) {
+        try {
+            String originalName = file.getOriginalFilename();
+            String ext = originalName != null && originalName.contains(".")
+                    ? originalName.substring(originalName.lastIndexOf(".")) : ".jpg";
+            String fileName = UUID.randomUUID().toString() + ext;
+
+            Path uploadPath = Paths.get(UPLOAD_DIR);
+            if (!Files.exists(uploadPath)) {
+                Files.createDirectories(uploadPath);
+            }
+
+            Path targetPath = uploadPath.resolve(fileName);
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            // ✅ 返回数据库存储的路径（与默认图一致）
+            String url = "/images/" + fileName;
+            return ResponseEntity.ok(Map.of("url", url, "message", "上传成功"));
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body(Map.of("error", "上传失败: " + e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/example/controller/ProductController.java
+++ b/src/main/java/com/example/controller/ProductController.java
@@ -1,25 +1,102 @@
 package com.example.controller;
-
+import com.example.dto.ProductCreateRequest;
+import com.example.dto.ProductDetailDTO;
 import com.example.dto.ProductListDTO;
+import com.example.dto.ProductUpdateDTO;
+import com.example.entity.Product;
 import com.example.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import java.math.BigDecimal;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
 @CrossOrigin(origins = "http://localhost:8081")
 public class ProductController {
-
     @Autowired
     private ProductService productService;
 
+    // ==========================================
+    // 1. 查询操作
+    // ==========================================
+
+    /**
+     * 商品列表与搜索
+     */
     @GetMapping
-    public ResponseEntity<List<ProductListDTO>> list(
+    public ResponseEntity<Page<ProductListDTO>> listProducts(
             @RequestParam(required = false) Integer categoryId,
-            @RequestParam(required = false) String keyword) {
-        return ResponseEntity.ok(productService.listProducts(categoryId, keyword));
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) BigDecimal minPrice,
+            @RequestParam(required = false) BigDecimal maxPrice,
+            @RequestParam(required = false) Byte conditionLevel,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        Page<ProductListDTO> products = productService.searchProducts(
+                categoryId, keyword, minPrice, maxPrice, conditionLevel, pageable);
+        return ResponseEntity.ok(products);
+    }
+
+    /**
+     * 获取我发布的商品
+     */
+    @GetMapping("/my")
+    public ResponseEntity<List<ProductListDTO>> getMyProducts(@RequestParam Long sellerId) {
+        List<ProductListDTO> products = productService.getMyProducts(sellerId);
+        return ResponseEntity.ok(products);
+    }
+
+    /**
+     * 商品详情
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductDetailDTO> getProductDetail(@PathVariable Long id) {
+        ProductDetailDTO detail = productService.getProductDetail(id);
+        return ResponseEntity.ok(detail);
+    }
+
+    // ==========================================
+    // 2. 增删改操作
+    // ==========================================
+
+    /**
+     * 发布商品
+     */
+    @PostMapping
+    public ResponseEntity<Product> createProduct(@RequestBody ProductCreateRequest request) {
+        Product created = productService.createProductWithImages(request);
+        return ResponseEntity.ok(created);
+    }
+
+    /**
+     * 更新商品
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<Product> updateProduct(@PathVariable Long id, @RequestBody ProductUpdateDTO dto) {
+        Product updatedProduct = productService.updateProduct(id, dto);
+        return ResponseEntity.ok(updatedProduct);
+    }
+
+    /**
+     * 上下架切换 (PATCH)
+     */
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Void> changeStatus(@PathVariable Long id, @RequestParam Byte status) {
+        productService.changeProductStatus(id, status);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * ✅ 删除商品 (DELETE) - 物理删除
+     * 注意：确保 Service 层有对应的 deleteProduct 方法
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+        productService.deleteProduct(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/dto/ProductCreateRequest.java
+++ b/src/main/java/com/example/dto/ProductCreateRequest.java
@@ -1,0 +1,67 @@
+package com.example.dto;
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 发布商品请求 DTO
+ * 用于接收前端提交的完整商品数据 + 图片列表
+ */
+public class ProductCreateRequest {
+    private String title;
+    private String description;
+    private BigDecimal price;
+    private BigDecimal originalPrice;
+    private Integer categoryId;
+    private Byte conditionLevel;
+    private String brand;
+    private Integer quantity;
+    private String campus;
+    private String tradeLocation;
+    private Byte tradeMethod;
+    private Byte isBargain;
+    private Long sellerId;
+    private List<String> imageUrls; // ✅ 图片URL列表
+
+    // ==================== Getter & Setter ====================
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+
+    public BigDecimal getOriginalPrice() { return originalPrice; }
+    public void setOriginalPrice(BigDecimal originalPrice) { this.originalPrice = originalPrice; }
+
+    public Integer getCategoryId() { return categoryId; }
+    public void setCategoryId(Integer categoryId) { this.categoryId = categoryId; }
+
+    public Byte getConditionLevel() { return conditionLevel; }
+    public void setConditionLevel(Byte conditionLevel) { this.conditionLevel = conditionLevel; }
+
+    public String getBrand() { return brand; }
+    public void setBrand(String brand) { this.brand = brand; }
+
+    public Integer getQuantity() { return quantity; }
+    public void setQuantity(Integer quantity) { this.quantity = quantity; }
+
+    public String getCampus() { return campus; }
+    public void setCampus(String campus) { this.campus = campus; }
+
+    public String getTradeLocation() { return tradeLocation; }
+    public void setTradeLocation(String tradeLocation) { this.tradeLocation = tradeLocation; }
+
+    public Byte getTradeMethod() { return tradeMethod; }
+    public void setTradeMethod(Byte tradeMethod) { this.tradeMethod = tradeMethod; }
+
+    public Byte getIsBargain() { return isBargain; }
+    public void setIsBargain(Byte isBargain) { this.isBargain = isBargain; }
+
+    public Long getSellerId() { return sellerId; }
+    public void setSellerId(Long sellerId) { this.sellerId = sellerId; }
+
+    public List<String> getImageUrls() { return imageUrls; }
+    public void setImageUrls(List<String> imageUrls) { this.imageUrls = imageUrls; }
+}

--- a/src/main/java/com/example/dto/ProductDetailDTO.java
+++ b/src/main/java/com/example/dto/ProductDetailDTO.java
@@ -1,0 +1,62 @@
+package com.example.dto;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ProductDetailDTO {
+    private Long id;
+    private String title;
+    private BigDecimal price;
+    private BigDecimal originalPrice;
+    private String description;
+    private String condition; // 已转换的成色文字，如 "9成新"
+    private String campus;
+    private String category;
+    private String tradeLocation;
+    private Byte tradeMethod;
+    private Byte isBargain;
+    private Integer viewCount;
+    private Long sellerId;
+    private String sellerName;
+    private String sellerAvatar;
+    private List<String> images;
+    private LocalDateTime createdAt;
+
+
+
+    // ==================== Getter & Setter ====================
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+    public BigDecimal getOriginalPrice() { return originalPrice; }
+    public void setOriginalPrice(BigDecimal originalPrice) { this.originalPrice = originalPrice; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getCondition() { return condition; }
+    public void setCondition(String condition) { this.condition = condition; }
+    public String getCampus() { return campus; }
+    public void setCampus(String campus) { this.campus = campus; }
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+    public String getTradeLocation() { return tradeLocation; }
+    public void setTradeLocation(String tradeLocation) { this.tradeLocation = tradeLocation; }
+    public Byte getTradeMethod() { return tradeMethod; }
+    public void setTradeMethod(Byte tradeMethod) { this.tradeMethod = tradeMethod; }
+    public Byte getIsBargain() { return isBargain; }
+    public void setIsBargain(Byte isBargain) { this.isBargain = isBargain; }
+    public Integer getViewCount() { return viewCount; }
+    public void setViewCount(Integer viewCount) { this.viewCount = viewCount; }
+    public Long getSellerId() { return sellerId; }
+    public void setSellerId(Long sellerId) { this.sellerId = sellerId; }
+    public String getSellerAvatar() {return sellerAvatar;}
+    public void setSellerAvatar(String sellerAvatar) {this.sellerAvatar = sellerAvatar;}
+    public String getSellerName() {return sellerName;}
+    public void setSellerName(String sellerName) {this.sellerName = sellerName;}
+    public List<String> getImages() { return images; }
+    public void setImages(List<String> images) { this.images = images; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/example/dto/ProductListDTO.java
+++ b/src/main/java/com/example/dto/ProductListDTO.java
@@ -1,9 +1,9 @@
 package com.example.dto;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public class ProductListDTO {
-
     private Long id;
     private String title;
     private BigDecimal price;
@@ -12,10 +12,19 @@ public class ProductListDTO {
     private String category;
     private String icon;
 
-    public ProductListDTO() {
-    }
+    // 新增：用于展示商品图片（列表页通常展示第一张或几张）
+    private List<String> images;
 
-    public ProductListDTO(Long id, String title, BigDecimal price, String condition, String campus, String category, String icon) {
+    // 新增：用于展示卖家信息或交易地点
+    private String tradeLocation;
+    private String sellerName; // 假设需要展示卖家昵称
+    private Byte status;
+    // 无参构造函数
+    public ProductListDTO() {}
+
+    // 全参构造函数（可根据需要调整）
+    public ProductListDTO(Long id, String title, BigDecimal price, String condition, String campus,
+                          String category, String icon, List<String> images, String tradeLocation) {
         this.id = id;
         this.title = title;
         this.price = price;
@@ -23,61 +32,41 @@ public class ProductListDTO {
         this.campus = campus;
         this.category = category;
         this.icon = icon;
+        this.images = images;
+        this.tradeLocation = tradeLocation;
     }
 
-    public Long getId() {
-        return id;
-    }
+    // Getter 和 Setter
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
 
-    public String getTitle() {
-        return title;
-    }
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
+    public String getCondition() { return condition; }
+    public void setCondition(String condition) { this.condition = condition; }
 
-    public BigDecimal getPrice() {
-        return price;
-    }
+    public String getCampus() { return campus; }
+    public void setCampus(String campus) { this.campus = campus; }
 
-    public void setPrice(BigDecimal price) {
-        this.price = price;
-    }
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
 
-    public String getCondition() {
-        return condition;
-    }
+    public String getIcon() { return icon; }
+    public void setIcon(String icon) { this.icon = icon; }
 
-    public void setCondition(String condition) {
-        this.condition = condition;
-    }
+    public List<String> getImages() { return images; }
+    public void setImages(List<String> images) { this.images = images; }
 
-    public String getCampus() {
-        return campus;
-    }
+    public String getTradeLocation() { return tradeLocation; }
+    public void setTradeLocation(String tradeLocation) { this.tradeLocation = tradeLocation; }
 
-    public void setCampus(String campus) {
-        this.campus = campus;
-    }
+    public String getSellerName() { return sellerName; }
+    public void setSellerName(String sellerName) { this.sellerName = sellerName; }
 
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getIcon() {
-        return icon;
-    }
-
-    public void setIcon(String icon) {
-        this.icon = icon;
-    }
+    public Byte getStatus() { return status; }
+    public void setStatus(Byte status) { this.status = status; }
 }

--- a/src/main/java/com/example/dto/ProductUpdateDTO.java
+++ b/src/main/java/com/example/dto/ProductUpdateDTO.java
@@ -1,0 +1,41 @@
+package com.example.dto;
+import java.math.BigDecimal;
+import java.util.List;
+
+public class ProductUpdateDTO {
+    private String title;
+    private String description;
+    private BigDecimal price;
+    private BigDecimal originalPrice;
+    private Integer categoryId;
+    private Byte conditionLevel;
+    private String campus;
+    private String tradeLocation;
+    private Byte tradeMethod;
+    private Byte isBargain;
+    private List<String> imageUrls; // 前端传入的全量图片URL列表
+
+    // ==================== Getter & Setter (IDE一键生成) ====================
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+    public BigDecimal getOriginalPrice() { return originalPrice; }
+    public void setOriginalPrice(BigDecimal originalPrice) { this.originalPrice = originalPrice; }
+    public Integer getCategoryId() { return categoryId; }
+    public void setCategoryId(Integer categoryId) { this.categoryId = categoryId; }
+    public Byte getConditionLevel() { return conditionLevel; }
+    public void setConditionLevel(Byte conditionLevel) { this.conditionLevel = conditionLevel; }
+    public String getCampus() { return campus; }
+    public void setCampus(String campus) { this.campus = campus; }
+    public String getTradeLocation() { return tradeLocation; }
+    public void setTradeLocation(String tradeLocation) { this.tradeLocation = tradeLocation; }
+    public Byte getTradeMethod() { return tradeMethod; }
+    public void setTradeMethod(Byte tradeMethod) { this.tradeMethod = tradeMethod; }
+    public Byte getIsBargain() { return isBargain; }
+    public void setIsBargain(Byte isBargain) { this.isBargain = isBargain; }
+    public List<String> getImageUrls() { return imageUrls; }
+    public void setImageUrls(List<String> imageUrls) { this.imageUrls = imageUrls; }
+}

--- a/src/main/java/com/example/entity/Category.java
+++ b/src/main/java/com/example/entity/Category.java
@@ -1,12 +1,10 @@
 package com.example.entity;
-
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "categories")
 public class Category {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
@@ -30,59 +28,25 @@ public class Category {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    public Integer getCategoryId() {
-        return categoryId;
-    }
+    // ==================== Getter & Setter (已修复空格错误) ====================
+    public Integer getCategoryId() { return categoryId; }
+    public void setCategoryId(Integer categoryId) { this.categoryId = categoryId; }
 
-    public void setCategoryId(Integer categoryId) {
-        this.categoryId = categoryId;
-    }
+    public Integer getParentId() { return parentId; }
+    public void setParentId(Integer parentId) { this.parentId = parentId; }
 
-    public Integer getParentId() {
-        return parentId;
-    }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
 
-    public void setParentId(Integer parentId) {
-        this.parentId = parentId;
-    }
+    public String getIconUrl() { return iconUrl; }
+    public void setIconUrl(String iconUrl) { this.iconUrl = iconUrl; }
 
-    public String getCategoryName() {
-        return categoryName;
-    }
+    public Integer getSortOrder() { return sortOrder; }
+    public void setSortOrder(Integer sortOrder) { this.sortOrder = sortOrder; }
 
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
+    public Byte getStatus() { return status; }
+    public void setStatus(Byte status) { this.status = status; }
 
-    public String getIconUrl() {
-        return iconUrl;
-    }
-
-    public void setIconUrl(String iconUrl) {
-        this.iconUrl = iconUrl;
-    }
-
-    public Integer getSortOrder() {
-        return sortOrder;
-    }
-
-    public void setSortOrder(Integer sortOrder) {
-        this.sortOrder = sortOrder;
-    }
-
-    public Byte getStatus() {
-        return status;
-    }
-
-    public void setStatus(Byte status) {
-        this.status = status;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 }

--- a/src/main/java/com/example/entity/Product.java
+++ b/src/main/java/com/example/entity/Product.java
@@ -1,4 +1,4 @@
-package com.example.entity;
+package com.example.entity; // 请根据你的实际包名修改
 
 import jakarta.persistence.*;
 import java.math.BigDecimal;
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 @Table(name = "products")
 public class Product {
 
+    // 1. 基础ID与卖家信息
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_id")
@@ -16,10 +17,16 @@ public class Product {
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
 
+    // 2. 分类与状态 (注意：数据库中是 category_id, status)
     @Column(name = "category_id", nullable = false)
     private Integer categoryId;
 
-    @Column(name = "title", nullable = false)
+    // 状态: 0-待审核 1-在售 2-已售出 3-已下架 4-审核不通过
+    @Column(name = "status", nullable = false)
+    private Byte status;
+
+    // 3. 核心信息 (标题、描述、价格)
+    @Column(name = "title", nullable = false, length = 200)
     private String title;
 
     @Column(name = "description", columnDefinition = "TEXT")
@@ -28,41 +35,48 @@ public class Product {
     @Column(name = "price", nullable = false, precision = 10, scale = 2)
     private BigDecimal price;
 
+    // 原价 (数据库定义中有 original_price)
     @Column(name = "original_price", precision = 10, scale = 2)
     private BigDecimal originalPrice;
 
+    // 4. 属性与规格 (品牌、新旧程度、数量)
+    @Column(name = "brand", length = 100)
+    private String brand;
+
+    // 新旧程度: 1-全新 2-几乎全新 3-轻微使用 4-明显使用 5-较旧
     @Column(name = "condition_level", nullable = false)
     private Byte conditionLevel;
 
-    @Column(name = "brand")
-    private String brand;
-
-    @Column(name = "quantity")
+    @Column(name = "quantity", nullable = false)
     private Integer quantity;
 
-    @Column(name = "campus", nullable = false)
+    // 5. 交易设置 (校区、地点、方式、议价)
+    @Column(name = "campus", nullable = false, length = 100)
     private String campus;
 
-    @Column(name = "trade_location")
+    // 交易地点 (之前遗漏的关键字段)
+    @Column(name = "trade_location", length = 255)
     private String tradeLocation;
 
-    @Column(name = "trade_method")
+    // 交易方式: 1-仅自提 2-仅快递 3-两者皆可
+    @Column(name = "trade_method", nullable = false)
     private Byte tradeMethod;
 
-    @Column(name = "is_bargain")
+    // 是否议价: 0-不议价 1-可议价
+    @Column(name = "is_bargain", nullable = false)
     private Byte isBargain;
 
-    @Column(name = "status")
-    private Byte status;
-
-    @Column(name = "view_count")
+    // 6. 统计与时间
+    @Column(name = "view_count", nullable = false)
     private Integer viewCount;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    // ==================== Getter 和 Setter ====================
 
     public Long getProductId() {
         return productId;
@@ -86,6 +100,14 @@ public class Product {
 
     public void setCategoryId(Integer categoryId) {
         this.categoryId = categoryId;
+    }
+
+    public Byte getStatus() {
+        return status;
+    }
+
+    public void setStatus(Byte status) {
+        this.status = status;
     }
 
     public String getTitle() {
@@ -120,20 +142,20 @@ public class Product {
         this.originalPrice = originalPrice;
     }
 
-    public Byte getConditionLevel() {
-        return conditionLevel;
-    }
-
-    public void setConditionLevel(Byte conditionLevel) {
-        this.conditionLevel = conditionLevel;
-    }
-
     public String getBrand() {
         return brand;
     }
 
     public void setBrand(String brand) {
         this.brand = brand;
+    }
+
+    public Byte getConditionLevel() {
+        return conditionLevel;
+    }
+
+    public void setConditionLevel(Byte conditionLevel) {
+        this.conditionLevel = conditionLevel;
     }
 
     public Integer getQuantity() {
@@ -174,14 +196,6 @@ public class Product {
 
     public void setIsBargain(Byte isBargain) {
         this.isBargain = isBargain;
-    }
-
-    public Byte getStatus() {
-        return status;
-    }
-
-    public void setStatus(Byte status) {
-        this.status = status;
     }
 
     public Integer getViewCount() {

--- a/src/main/java/com/example/entity/ProductImage.java
+++ b/src/main/java/com/example/entity/ProductImage.java
@@ -1,0 +1,41 @@
+package com.example.entity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "product_images")
+public class ProductImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    @Column(name = "is_cover")
+    private Byte isCover;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    // Getter 和 Setter（略，请确保全部生成）
+    public Long getImageId() { return imageId; }
+    public void setImageId(Long imageId) { this.imageId = imageId; }
+    public Long getProductId() { return productId; }
+    public void setProductId(Long productId) { this.productId = productId; }
+    public String getImageUrl() { return imageUrl; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+    public Integer getSortOrder() { return sortOrder; }
+    public void setSortOrder(Integer sortOrder) { this.sortOrder = sortOrder; }
+    public Byte getIsCover() { return isCover; }
+    public void setIsCover(Byte isCover) { this.isCover = isCover; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/example/repository/ProductImageRepository.java
+++ b/src/main/java/com/example/repository/ProductImageRepository.java
@@ -1,0 +1,18 @@
+package com.example.repository;
+import com.example.entity.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+    // 按单个商品查
+    List<ProductImage> findByProductIdOrderBySortOrderAsc(Long productId);
+
+    // ✅ 新增：按多个商品 ID 批量查（关键！）
+    List<ProductImage> findByProductIdInOrderByProductIdAscSortOrderAsc(List<Long> productIds);
+
+
+
+    void deleteByProductId(Long productId);
+}

--- a/src/main/java/com/example/repository/ProductRepository.java
+++ b/src/main/java/com/example/repository/ProductRepository.java
@@ -13,4 +13,9 @@ public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpec
     List<Product> findByCategoryIdAndStatusOrderByCreatedAtDesc(Integer categoryId, Byte status);
     List<Product> findByTitleContainingAndStatusOrderByCreatedAtDesc(String title, Byte status);
     List<Product> findByCategoryIdAndTitleContainingAndStatusOrderByCreatedAtDesc(Integer categoryId, String title, Byte status);
+    // 根据卖家ID和状态查询，按创建时间倒序
+    List<Product> findBySellerIdAndStatusOrderByCreatedAtDesc(Long sellerId, Byte status);
+    // 如果需要查询所有状态（包括已下架），可以再加一个：
+    List<Product> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
+    void deleteByProductId(Long productId);
 }

--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -12,7 +12,6 @@ import com.example.repository.CategoryRepository;
 import com.example.repository.ProductImageRepository;
 import com.example.repository.ProductRepository;
 import com.example.repository.UserRepository;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageImpl;

--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -1,16 +1,33 @@
 package com.example.service;
 
+import com.example.dto.ProductCreateRequest;
+import com.example.dto.ProductDetailDTO;
 import com.example.dto.ProductListDTO;
+import com.example.dto.ProductUpdateDTO;
 import com.example.entity.Category;
 import com.example.entity.Product;
+import com.example.entity.ProductImage;
+import com.example.entity.User;
 import com.example.repository.CategoryRepository;
+import com.example.repository.ProductImageRepository;
 import com.example.repository.ProductRepository;
+import com.example.repository.UserRepository;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-import java.util.Map;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import jakarta.persistence.criteria.*;
 
 @Service
 public class ProductService {
@@ -21,53 +38,382 @@ public class ProductService {
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private ProductImageRepository productImageRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Value("${app.base-url:http://localhost:8087}")
+    private String baseUrl;
+
+    private static final Byte STATUS_ON_SALE = 1; // 在售状态
+
     private static final Map<Byte, String> CONDITION_MAP = Map.of(
             (byte) 1, "全新",
             (byte) 2, "99新",
             (byte) 3, "95新",
-            (byte) 4, "9新",
-            (byte) 5, "85新"
+            (byte) 4, "9成新",
+            (byte) 5, "8成新",
+            (byte) 6, "7成新及以下" // 补全你前端定义的第6级
     );
 
     private static final Map<Integer, String> ICON_MAP = Map.of(
-            1, "digital",
-            2, "books",
-            3, "life",
-            4, "transport",
-            5, "beauty",
-            6, "clothes",
-            7, "box"
+            1, "digital", 2, "books", 3, "life",
+            4, "transport", 5, "beauty", 6, "clothes", 7, "box"
     );
 
-    public List<ProductListDTO> listProducts(Integer categoryId, String keyword) {
-        List<Product> products;
-        Byte status = 1;
+    /**
+     * 增强版搜索与筛选 (使用 Specification)
+     */
+    public Page<ProductListDTO> searchProducts(Integer categoryId, String keyword,
+                                               BigDecimal minPrice, BigDecimal maxPrice,
+                                               Byte conditionLevel,Pageable pageable) {
 
-        if (categoryId != null && keyword != null && !keyword.isBlank()) {
-            products = productRepository.findByCategoryIdAndTitleContainingAndStatusOrderByCreatedAtDesc(categoryId, keyword, status);
-        } else if (categoryId != null) {
-            products = productRepository.findByCategoryIdAndStatusOrderByCreatedAtDesc(categoryId, status);
-        } else if (keyword != null && !keyword.isBlank()) {
-            products = productRepository.findByTitleContainingAndStatusOrderByCreatedAtDesc(keyword, status);
+        Specification<Product> spec = (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // 1. 状态：仅查询在售商品
+            predicates.add(criteriaBuilder.equal(root.get("status"), STATUS_ON_SALE));
+
+            // 2. 分类筛选
+            if (categoryId != null) {
+                predicates.add(criteriaBuilder.equal(root.get("categoryId"), categoryId));
+            }
+
+            // 3. 关键词筛选 (标题模糊匹配)
+            if (keyword != null && !keyword.trim().isEmpty()) {
+                predicates.add(criteriaBuilder.like(root.get("title"), "%" + keyword + "%"));
+            }
+
+            // 4. 价格区间筛选
+            if (minPrice != null) {
+                predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("price"), minPrice));
+            }
+            if (maxPrice != null) {
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("price"), maxPrice));
+            }
+
+            // 5. 新旧程度筛选
+            if (conditionLevel != null && conditionLevel >= 1 && conditionLevel <= 6) {
+                predicates.add(criteriaBuilder.equal(root.get("conditionLevel"), conditionLevel));
+            }
+
+            predicates.add(criteriaBuilder.equal(root.get("status"), STATUS_ON_SALE));
+
+            if(categoryId != null){
+                predicates.add(criteriaBuilder.equal(root.get("categoryId"), categoryId));
+            }
+
+            if(keyword != null && !keyword.trim().isEmpty()) {
+                predicates.add(criteriaBuilder.like(root.get("title"), "%" + keyword + "%"));
+            }
+
+            if(minPrice != null){
+                predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("price"), minPrice));
+            }
+
+            if(maxPrice != null){
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("price"), maxPrice));
+            }
+
+            if(conditionLevel != null && conditionLevel >= 1 && conditionLevel <= 6) {
+                predicates.add(criteriaBuilder.equal(root.get("conditionLevel"), conditionLevel));
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+
+        // 2. 关键修改：将 Pageable 传入 findAll，直接返回 Page<Product>
+        // 这样才能利用数据库的分页能力（如 LIMIT/OFFSET），而不是查出所有数据
+        org.springframework.data.domain.Page<Product> productPage =
+                productRepository.findAll(spec, pageable);
+
+        // 3. 将查出的实体 Page 转换为 DTO Page
+        // 注意：这里不能直接用 convertToDTOList，因为那是转 List 的
+        // 我们需要构造一个新的 PageImpl
+        List<ProductListDTO> dtoList = convertToDTOList(productPage.getContent());
+
+        return new PageImpl<>(dtoList, pageable, productPage.getTotalElements());
+    }
+
+    /**
+     * 获取商品详情（含图片、分类名、成色文字）
+     */
+    public ProductDetailDTO getProductDetail(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("商品未找到"));
+
+        // 增加浏览量
+        product.setViewCount(product.getViewCount() == null ? 1 : product.getViewCount() + 1);
+        productRepository.save(product);
+
+        ProductDetailDTO dto = new ProductDetailDTO();
+        dto.setId(product.getProductId());
+        dto.setTitle(product.getTitle());
+        dto.setPrice(product.getPrice());
+        dto.setOriginalPrice(product.getOriginalPrice());
+        dto.setDescription(product.getDescription());
+        dto.setCondition(CONDITION_MAP.getOrDefault(product.getConditionLevel(), "未知").trim());
+        dto.setCampus(product.getCampus());
+        dto.setTradeLocation(product.getTradeLocation());
+        dto.setTradeMethod(product.getTradeMethod());
+        dto.setIsBargain(product.getIsBargain());
+        dto.setViewCount(product.getViewCount());
+        dto.setSellerId(product.getSellerId());
+        dto.setCreatedAt(product.getCreatedAt()); // ✅ 修复 createdAt 为 null
+
+        // 1. ✅ 修复 category 为 null：关联查询分类表
+        Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
+        dto.setCategory(category != null ? category.getCategoryName() : "未知分类");
+
+        // 2. ✅ 修复 images 为 null：关联查询图片表并补全 URL
+        List<ProductImage> productImages = productImageRepository.findByProductIdOrderBySortOrderAsc(product.getProductId());
+        List<String> imageUrls = productImages.stream()
+                .map(ProductImage::getImageUrl)
+                .map(url -> {
+                    if (url != null && url.startsWith("/") && !url.contains("http")) {
+                        return "http://localhost:8087" + url; // 你的后端端口
+                    }
+                    return url;
+                })
+                .collect(Collectors.toList());
+
+        if (imageUrls.isEmpty()) {
+            imageUrls.add("https://placehold.co/800x800/eee/999?text=No+Image");
+        }
+        dto.setImages(imageUrls);
+
+        // 3. ✅ 修复卖家信息
+        User seller = userRepository.findById(product.getSellerId()).orElse(null);
+        if (seller != null) {
+            dto.setSellerName(seller.getUsername());
+            dto.setSellerAvatar(seller.getAvatarUrl()); // 若 DB 中该用户没传头像，此处自然为 null
         } else {
-            products = productRepository.findByStatusOrderByCreatedAtDesc(status);
+            dto.setSellerName("匿名用户");
+            dto.setSellerAvatar(null);
         }
 
+        return dto;
+    }
+
+    // 辅助方法：根据 ID 获取分类名称
+    private String getCategoryName(Integer categoryId) {
+        return categoryRepository.findById(categoryId)
+                .map(Category::getCategoryName)
+                .orElse("未知分类");
+    }
+
+    /**
+     * 发布商品
+     */
+    @Transactional
+    public Product createProductWithImages(ProductCreateRequest req) {
+        // 1. 保存商品主体
+        Product product = new Product();
+        product.setTitle(req.getTitle());
+        product.setDescription(req.getDescription());
+        product.setPrice(req.getPrice());
+        product.setOriginalPrice(req.getOriginalPrice());
+        product.setCategoryId(req.getCategoryId());
+        product.setConditionLevel(req.getConditionLevel());
+        product.setBrand(req.getBrand());
+        product.setQuantity(req.getQuantity() != null ? req.getQuantity() : 1);
+        product.setCampus(req.getCampus());
+        product.setTradeLocation(req.getTradeLocation());
+        product.setTradeMethod(req.getTradeMethod() != null ? req.getTradeMethod() : (byte) 3);
+        product.setIsBargain(req.getIsBargain() != null ? req.getIsBargain() : (byte) 1);
+        product.setSellerId(req.getSellerId());
+        product.setStatus(STATUS_ON_SALE); // 1-在售
+        product.setViewCount(0);
+        product.setCreatedAt(LocalDateTime.now());
+        product.setUpdatedAt(LocalDateTime.now());
+
+        Product savedProduct = productRepository.save(product);
+        Long productId = savedProduct.getProductId();
+
+        // 2. ✅ 批量插入图片记录（如果存在）
+        if (req.getImageUrls() != null && !req.getImageUrls().isEmpty()) {
+            List<ProductImage> images = new ArrayList<>();
+            for (int i = 0; i < req.getImageUrls().size(); i++) {
+                ProductImage img = new ProductImage();
+                img.setProductId(productId);
+                img.setImageUrl(req.getImageUrls().get(i));
+                img.setSortOrder(i);  // 排序：首张为封面
+                img.setIsCover(i == 0 ? (byte) 1 : (byte) 0);  // 首张设为封面
+                img.setCreatedAt(LocalDateTime.now());
+                images.add(img);
+            }
+            // 批量保存，效率高
+            productImageRepository.saveAll(images);
+        }
+
+        return savedProduct;
+    }
+
+    /**
+     * 更新商品信息
+     */
+    @Transactional
+    public Product updateProduct(Long id, ProductUpdateDTO dto) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("商品未找到"));
+
+        // 更新基础字段
+        product.setTitle(dto.getTitle());
+        product.setDescription(dto.getDescription());
+        product.setPrice(dto.getPrice());
+        product.setOriginalPrice(dto.getOriginalPrice());
+        product.setCategoryId(dto.getCategoryId());
+        product.setConditionLevel(dto.getConditionLevel());
+        product.setCampus(dto.getCampus());
+        product.setTradeLocation(dto.getTradeLocation());
+        product.setTradeMethod(dto.getTradeMethod());
+        product.setIsBargain(dto.getIsBargain());
+        product.setUpdatedAt(LocalDateTime.now());
+
+        // ✅ 替换图片：先删后增
+        if (dto.getImageUrls() != null) {
+            productImageRepository.deleteByProductId(id);
+            if (!dto.getImageUrls().isEmpty()) {
+                List<ProductImage> newImages = new ArrayList<>();
+                for (int i = 0; i < dto.getImageUrls().size(); i++) {
+                    ProductImage img = new ProductImage();
+                    img.setProductId(id);
+                    img.setImageUrl(dto.getImageUrls().get(i));
+                    img.setSortOrder(i);
+                    img.setIsCover(i == 0 ? (byte) 1 : (byte) 0);
+                    img.setCreatedAt(LocalDateTime.now());
+                    newImages.add(img);
+                }
+                productImageRepository.saveAll(newImages);
+            }
+        }
+        return productRepository.save(product);
+    }
+
+    /**
+     * 切换上下架状态
+     * @param status 1-在售 3-已下架
+     */
+    @Transactional
+    public void changeProductStatus(Long id, Byte status) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("商品未找到"));
+        if (status != 1 && status != 3) {
+            throw new RuntimeException("状态参数无效");
+        }
+        product.setStatus(status);
+        product.setUpdatedAt(LocalDateTime.now());
+        productRepository.save(product);
+    }
+
+
+    /**
+     * 下架商品
+     */
+    @Transactional
+    public void deactivateProduct(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("商品未找到"));
+        product.setStatus((byte) 3); // 3-已下架
+        // 修复：使用 LocalDateTime
+        product.setUpdatedAt(LocalDateTime.now());
+        productRepository.save(product);
+    }
+
+    /**
+     * 彻底删除商品（含关联图片）
+     */
+    @Transactional
+    public void deleteProduct(Long id) {
+        // 1. 先删图片记录（避免外键约束报错，如果配置了 CASCADE 可省略，但显式删除更安全）
+        productImageRepository.deleteByProductId(id);
+
+        // 2. 再删商品主体
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("商品未找到"));
+        productRepository.delete(product);
+    }
+
+    /**
+     * 获取我发布的商品列表
+     */
+    public List<ProductListDTO> getMyProducts(Long sellerId) {
+        // 这里我们查询所有状态的商品，方便管理下架商品
+        List<Product> products = productRepository.findBySellerIdOrderByCreatedAtDesc(sellerId);
+        return convertToDTOList(products);
+    }
+
+    // ==================== 私有辅助方法 ====================
+
+    /**
+     * 将 Product 实体列表转换为 DTO 列表
+     */
+    private List<ProductListDTO> convertToDTOList(List<Product> products) {
+        if (products == null || products.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 1. 获取所有分类信息用于映射
         List<Category> categories = categoryRepository.findByStatusOrderBySortOrderAsc((byte) 1);
         Map<Integer, String> categoryNameMap = categories.stream()
                 .collect(Collectors.toMap(Category::getCategoryId, Category::getCategoryName));
         Map<Integer, String> categoryIconMap = categories.stream()
                 .collect(Collectors.toMap(Category::getCategoryId, c -> ICON_MAP.getOrDefault(c.getCategoryId(), "box")));
 
+        // 2. 获取所有商品的图片（优化：批量查询，避免 N+1 问题）
+        List<Long> productIds = products.stream()
+                .map(Product::getProductId)
+                .collect(Collectors.toList());
+
+        // 查询所有相关图片
+        List<ProductImage> allImages = productImageRepository
+                .findByProductIdInOrderByProductIdAscSortOrderAsc(productIds);
+
+        // 按 productId 分组，方便快速查找
+        Map<Long, List<ProductImage>> imagesMap = allImages.stream()
+                .collect(Collectors.groupingBy(ProductImage::getProductId));
+
+        // 3. 组装 DTO
         return products.stream().map(p -> {
             ProductListDTO dto = new ProductListDTO();
             dto.setId(p.getProductId());
             dto.setTitle(p.getTitle());
             dto.setPrice(p.getPrice());
-            dto.setCondition(CONDITION_MAP.getOrDefault(p.getConditionLevel(), "未知"));
+
+            // ✅ 核心修复 1：必须设置 status，否则前端无法判断上下架状态
+            dto.setStatus(p.getStatus());
+
+            dto.setCondition(CONDITION_MAP.getOrDefault(p.getConditionLevel(), "未知").trim());
             dto.setCampus(p.getCampus());
-            dto.setCategory(categoryNameMap.getOrDefault(p.getCategoryId(), ""));
+
+            // 处理分类名称，防止 null
+            String catName = categoryNameMap.getOrDefault(p.getCategoryId(), "其他");
+            dto.setCategory(catName);
             dto.setIcon(categoryIconMap.getOrDefault(p.getCategoryId(), "box"));
+
+            dto.setTradeLocation(p.getTradeLocation());
+
+            // ✅ 核心修复 2：处理图片并拼接 baseUrl
+            List<ProductImage> productImages = imagesMap.getOrDefault(p.getProductId(), Collections.emptyList());
+            List<String> imageUrls = productImages.stream()
+                    .map(ProductImage::getImageUrl)
+                    .map(url -> {
+                        // 如果是相对路径且不为空，拼接后端地址
+                        if (url != null && url.startsWith("/") && !url.contains("http")) {
+                            return baseUrl + url;
+                        }
+                        return url;
+                    })
+                    .collect(Collectors.toList());
+
+            // 如果没有图片，使用在线默认图兜底
+            if (imageUrls.isEmpty()) {
+                imageUrls.add("https://placehold.co/400x400/eee/999?text=No+Image");
+            }
+            dto.setImages(imageUrls);
+
             return dto;
         }).collect(Collectors.toList());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,10 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/campus_trade?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=982100
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 
 server.port=8087
+app.base-url=http://localhost:8087


### PR DESCRIPTION
本 PR 完成了校园二手交易平台核心物品管理模块的开发与优化，实现了从商品发布到个人管理的完整闭环。主要修改逻辑如下：
1. 核心功能实现
商品发布 (Publish.vue)：
新增多图上传功能，支持预览、删除及自动关联至 product_images表。
补充“是否议价”选项，并修复了前后端字段映射不一致导致的提交失败问题。
增加顶部“取消发布”返回按钮，提升用户体验。
商品编辑与状态管理 (EditProduct.vue & ProductDetail.vue)：
实现商品详情编辑功能，支持修改标题、价格、描述及图片替换。
在详情页和“我发布的”列表中增加上下架切换功能（PATCH /api/products/{id}/status），卖家可一键控制商品可见性。
增加权限校验，仅商品所有者可见编辑与下架按钮。
个人管理中心 (MyProducts.vue)：
新增“我发布的”页面，展示用户所有商品（含已下架）。
支持在列表页直接进行编辑、上下架切换及物理删除操作。
修复了后端查询接口缺失导致的列表为空问题。
2. 后端架构优化
DTO 规范化：新建 ProductCreateRequest、ProductUpdateDTO 和 ProductDetailDTO，解决实体类与前端交互字段不匹配的问题。
图片关联逻辑重构：
采用“先删后增”策略处理编辑时的图片更新，确保 product_images 表数据一致性。
在 convertToDTOList 中显式设置 status 字段，修复前端状态显示错误。
统一图片路径处理，通过 baseUrl 配置自动拼接绝对路径，解决跨端口访问 404 问题。
接口完善：
新增 GET /api/products/my 接口，支持按卖家 ID 查询全量商品。
新增 DELETE /api/products/{id} 接口，实现级联删除商品及其关联图片。
3. Bug 修复与体验优化
路由导航：为 MyProducts、Publish、EditProduct 和 ProductDetail 页面统一增加返回上一页按钮，解决移动端返回困难问题。
安全配置：在 SecurityConfig 中显式允许 PATCH 和 OPTIONS 方法，修复上下架接口报 403 Forbidden 的问题。
数据一致性：修复了 ProductService 中因缺少 status 赋值导致前端全部显示“已下架”的严重 Bug。